### PR TITLE
v1.1.1 — scorecard schema + $schema field + issue cleanup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "verdict",
       "source": "./",
       "description": "Auto-evaluates skill and agent execution quality with 7-dimension scoring, configurable rubrics, and dual-mode operation.",
-      "version": "1.1.0",
+      "version": "1.2.0-beta.1",
       "category": "quality-assurance",
       "tags": ["judge", "evaluation", "quality", "scoring", "LLM-as-judge"],
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verdict",
-  "version": "1.1.0",
+  "version": "1.2.0-beta.1",
   "displayName": "Verdict — Universal Skill & Agent Quality Judge",
   "description": "The first universal judge for Claude Code & Cowork. Auto-evaluates skill and agent execution quality with 7-dimension scoring, configurable rubrics, and dual-mode operation (auto hooks + manual /judge command).",
   "author": {

--- a/.github/workflows/self-score.yml
+++ b/.github/workflows/self-score.yml
@@ -1,0 +1,156 @@
+name: Self-score
+
+# Dogfooding gate. Treat the PR title + body + changed-files list as a
+# synthetic transcript and run Verdict's own heuristic pass on it. Fail
+# when the composite drops below the threshold (default 7.0). The
+# scorecard is posted as a PR comment so reviewers see the signal
+# alongside test + marketplace validator output.
+#
+# The self-score is intentionally loose: it doesn't read actual diff
+# content, only metadata. Its job is to catch PRs that look obviously
+# incomplete (no description, dozens of touched files with "TODO" in
+# their names, etc.), not to evaluate code quality.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, edited]
+
+concurrency:
+  group: self-score-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  self-score:
+    name: Score this PR against the code-review rubric
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR head
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Build synthetic transcript from PR metadata
+        id: transcript
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY:  ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          mkdir -p .self-score
+          TRANSCRIPT=.self-score/transcript.txt
+
+          {
+            echo "User: /code-review PR #${{ github.event.pull_request.number }}: ${PR_TITLE:-<no title>}"
+            echo ""
+            echo "Description:"
+            echo "${PR_BODY:-<no description>}"
+            echo ""
+            echo "Changed files:"
+            git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD \
+              | head -200
+            echo ""
+            echo "Shortstat:"
+            git diff --shortstat origin/${{ github.event.pull_request.base.ref }}...HEAD
+          } > "${TRANSCRIPT}"
+
+          echo "transcript=${TRANSCRIPT}" >> "${GITHUB_OUTPUT}"
+          echo "Generated transcript (${TRANSCRIPT}):"
+          head -40 "${TRANSCRIPT}"
+
+      - name: Run Verdict self-score
+        id: score
+        run: |
+          set -euo pipefail
+          mkdir -p .self-score/out
+          python3 skills/judge/scripts/score.py \
+            --skill code-review \
+            --transcript "${{ steps.transcript.outputs.transcript }}" \
+            --rubric-dir skills/judge/rubrics \
+            --scores-dir .self-score/out \
+            --config judge-config.json \
+            > .self-score/scorecard.json
+          python3 -c "
+          import json, sys
+          card = json.load(open('.self-score/scorecard.json'))
+          print(f\"composite={card['composite_score']}\")
+          print(f\"grade={card['grade']}\")
+          print(f\"one_liner={card.get('one_liner', '')}\")
+          "
+
+      - name: Validate threshold
+        id: threshold
+        run: |
+          set -euo pipefail
+          THRESHOLD="${VERDICT_PR_THRESHOLD:-7.0}"
+          COMPOSITE=$(python3 -c "import json; print(json.load(open('.self-score/scorecard.json'))['composite_score'])")
+          echo "composite=${COMPOSITE}" >> "${GITHUB_OUTPUT}"
+          echo "threshold=${THRESHOLD}" >> "${GITHUB_OUTPUT}"
+          python3 -c "
+          import sys
+          composite = float('${COMPOSITE}')
+          threshold = float('${THRESHOLD}')
+          sys.exit(0 if composite >= threshold else 1)
+          " || {
+            echo "::error title=Self-score below threshold::composite ${COMPOSITE} < threshold ${THRESHOLD}"
+            exit 1
+          }
+
+      - name: Render Unicode scorecard
+        if: always()
+        id: render
+        run: |
+          set -euo pipefail
+          python3 skills/judge/scripts/report.py \
+            --scores-dir .self-score/out \
+            --skill code-review \
+            --last 1 \
+            > .self-score/report.txt
+          echo '```'  > .self-score/comment.md
+          cat       .self-score/report.txt >> .self-score/comment.md
+          echo '```' >> .self-score/comment.md
+          echo ''    >> .self-score/comment.md
+          echo "*Self-score on PR metadata — threshold ${{ steps.threshold.outputs.threshold }}. See [docs/launch/dogfood-ci.md](../tree/main/docs/launch) for rationale.*" \
+            >> .self-score/comment.md
+
+      - name: Post or update PR comment
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('.self-score/comment.md', 'utf8');
+            const marker = '<!-- verdict-self-score -->';
+            const payload = `${marker}\n${body}`;
+
+            const {data: comments} = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                comment_id: existing.id,
+                body: payload,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: context.issue.number,
+                body: payload,
+              });
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,67 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0-beta.1] - 2026-04-19
+
+### Added
+
+- **Scorecard schema** (`schemas/scorecard.v1.schema.json`) — JSON
+  Schema draft 2020-12 describing every field of the persisted scorecard
+  JSON, with per-dimension entries and forward-compatible slots for LLM
+  second-opinion output.
+- **`$schema` + `schemaVersion` fields** on every persisted scorecard.
+  Injected by `save_score`; callers can't forget or override the
+  canonical identifiers. Consumers should pin `schemaVersion >= 1.0.0,
+  < 2.0.0`.
+- **DEEP_ANALYSIS.md §Schema stability contract** documenting SemVer
+  rules, deprecation window, and test surface for the v1 schema line.
+- **Opt-in LLM second-opinion analyzer**
+  (`skills/judge/analyzers/llm_judge.py`). When
+  `judge-config.json.llm_second_opinion.enabled = true` and
+  `ANTHROPIC_API_KEY` is set, Verdict emits both heuristic and LLM
+  scores under `dimensions[dim].llm_score` /
+  `dimensions[dim].llm_justification`. Stdlib-only HTTP
+  (`urllib.request`); no `anthropic` package is imported. Sends the
+  `task-budgets-2026-03-13` beta header when `budget_tokens` is set.
+  Transcripts over 16k chars are truncated with a head/tail split and
+  an elision marker.
+- **Gemini CLI adapter** (`skills/judge/adapters/gemini_cli.py`).
+  Handles `parts[]`, flattened `content`, `functionCall`, and
+  `functionResponse` shapes; registered under both `gemini-cli` and
+  `gemini`.
+- **`/judge --watch` live re-scoring** (`skills/judge/scripts/watch.py`).
+  Polls `scores/` every 2 s, renders a diff header per change
+  (`improved X, regressed Y, unchanged Z since last run`), and
+  re-emits Verdict Studio.
+- **Dogfood self-score CI gate**
+  (`.github/workflows/self-score.yml`). Treats the PR title + body +
+  changed-files list as a synthetic transcript, scores it against the
+  code-review rubric, and fails the job when composite drops below
+  the `VERDICT_PR_THRESHOLD` (default 7.0). Scorecard posted as a PR
+  comment.
+- **Scorecard fixtures** at `tests/fixtures/scorecards/` — canonical
+  examples covering every adapter / rubric path; every fixture must
+  validate against the shipped schema on every CI run.
+
+### Changed
+
+- `/judge` usage line now documents `--adapter`, `--model`,
+  `--against`, `--watch`, and `--llm-second-opinion` flags; includes
+  `gemini-cli` in the adapter list.
+- Version bumps to `1.2.0-beta.1` across `plugin.json`,
+  `marketplace.json`, and `SKILL.md`.
+
+### Tests
+
+- 262 → 314 (+52). New suites: `test_schema.py`, `test_llm_judge.py`,
+  `test_watch.py`; Gemini cases added to `test_adapters.py` and
+  `test_adapter_fixtures.py`.
+
+### Out of scope for this beta
+
+Rubric marketplace index (P2), scorecard delta webhook (P2),
+`verdict` PyPI shim (P2), MLflow integration (future).
+
 ## [1.1.0] - 2026-04-18
 
 ### Added

--- a/DEEP_ANALYSIS.md
+++ b/DEEP_ANALYSIS.md
@@ -298,3 +298,82 @@ Coverage by category:
 ## 13. Bottom line
 
 Verdict is a **tight, principled starting point** for plugin-based quality evaluation on Claude Code and Cowork. Its strengths — zero-dependency Python, a strong test suite, well-structured domain rubrics, dual-mode (auto + manual), and persistent JSON scorecards — are exactly right for a v1.0 release. The next release should treat the regex analyzers as a *fallback* behind an optional LLM judge and address the length-as-proxy and neutral-baseline biases. Once those are fixed, Verdict can credibly claim the "universal" in its tagline.
+
+---
+
+## 14. Schema stability contract *(added 2026-04-19 with v1.1.1)*
+
+Every persisted scorecard JSON carries `"$schema"` and `"schemaVersion"`
+fields at the top of the document. These are injected unconditionally by
+`skills/judge/scripts/score.py::save_score`; no caller needs to supply
+them. The canonical schema lives at
+`schemas/scorecard.v1.schema.json` and is tested against every fixture
+in `tests/fixtures/scorecards/` via `tests/test_schema.py`.
+
+### Identifiers
+
+- `$schema`: `https://verdict.dev/schemas/scorecard.v1.json` — stable
+  URI that never changes for the v1 line of the schema. The domain will
+  resolve to a static copy of the schema once `verdict.dev` is live; until
+  then the URI is a logical identifier and the authoritative copy is the
+  file in-repo.
+- `schemaVersion`: SemVer string `"MAJOR.MINOR.PATCH"`.
+  - **MAJOR** is pinned to `1` for this schema URI. A breaking change
+    (removal of a field, change of a type, change of an enum value,
+    change of a required-list) forces a new schema file at
+    `schemas/scorecard.v2.schema.json` and a new URI.
+  - **MINOR** bumps for additive-compatible changes: new optional
+    properties, new enum values on an open enum, newly relaxed
+    constraints. Consumers that pin to `schemaVersion >= 1.1.0` must
+    keep parsing older documents.
+  - **PATCH** bumps are purely editorial: reworded `description` text,
+    doc typos, tightened `additionalProperties: true → true with a
+    pattern`, and the like.
+
+### Evolution rules
+
+- New **required** top-level field → MAJOR bump (old consumers break).
+- New **optional** top-level field → MINOR bump.
+- New dimension in `dimensions` → MAJOR bump (existing consumers iterate
+  the seven canonical keys and would miss it); this is avoided in
+  practice by adding LLM-side data inside the existing dimension entry
+  (`dimensions.correctness.llm_score` et al.).
+- Enum extension (e.g. a new grade tier) → MINOR bump if old consumers
+  can safely ignore the new value, MAJOR otherwise.
+- Removing a field that was optional → MINOR bump and a deprecation
+  note in `CHANGELOG.md`.
+- Renaming a field → treated as remove+add, so MAJOR.
+
+### Deprecation window
+
+Fields marked for removal ship in a MINOR release with a
+`"deprecated": true` note in their `description`, then are removed only
+in the next MAJOR. Consumers should check `schemaVersion` and fall back
+to the legacy field when parsing older documents.
+
+### Consumer pinning
+
+Downstream tools (including Verdict Studio, `benchmark_pack.py`, and
+external dashboards) should parse `schemaVersion` first. The minimum
+compatible pin is `>= 1.0.0, < 2.0.0`. Any tool that needs a v1.1+
+field should guard on `schemaVersion` and degrade gracefully for
+v1.0.x documents.
+
+### Test surface
+
+- `tests/test_schema.py::TestSchemaFileWellFormed` — schema itself
+  parses and advertises the correct `$id`.
+- `tests/test_schema.py::TestPersistedFixtures` — every file in
+  `tests/fixtures/scorecards/` validates against the schema and carries
+  the right `$schema`/`schemaVersion` values.
+- `tests/test_schema.py::TestPersistInjection` — `save_score` injects
+  both fields on every write, idempotently, even when the caller's dict
+  already carries them (canonical values win).
+
+### Rationale
+
+Before v1.1.1 the scorecard JSON was a moving target: any downstream
+consumer that parsed last week's scorecard broke when we added fields
+(`model`, `tokenizer_baseline`, `weights_source`). The schema contract
+converts that implicit API into an explicit one and gives future
+consumers a version they can pin against.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,118 @@
+# PR draft — `v1.1.1 → v1.2.0-beta.1` landing
+
+Copy-paste the body below when you open the PR. The title line is the
+repository's expected convention; keep it if you can. This file is
+intentionally committed so you can eyeball the draft locally before
+publishing.
+
+---
+
+## PR title
+
+```
+v1.1.1 — scorecard schema + $schema field + issue cleanup (plus v1.2.0-beta.1 features)
+```
+
+## PR base / head
+
+- base: `main`
+- head: `feat/v1.2.0-schema-llm-opinion`
+
+## PR body
+
+Executes the 2026-04-19 Claude Code Prompt (Thread A). Every task
+below has a commit + tests; the branch grows 262 → 314 passing tests.
+
+### Thread A — tasks completed
+
+- **A1 — `scorecard.v1.schema.json` + `$schema` field.** Canonical
+  JSON Schema at `schemas/scorecard.v1.schema.json`. `save_score`
+  injects `$schema` and `schemaVersion` at the top of every emitted
+  document. DEEP_ANALYSIS.md §Schema stability contract documents the
+  SemVer rules. New suites: `tests/test_schema.py`, `tests/_schema_validator.py`
+  (stdlib-only validator so we don't take a `jsonschema` dep), and
+  four committed scorecard fixtures under
+  `tests/fixtures/scorecards/`.
+
+- **A2 — issue hygiene.** [#2][i2] closed with a summary covering
+  every completed v1.1.0 item; [#3][i3] opened for v1.2.0 tracking.
+  [i2]: https://github.com/sattyamjjain/verdict/issues/2
+  [i3]: https://github.com/sattyamjjain/verdict/issues/3
+
+- **A3 — opt-in LLM second-opinion analyzer.**
+  `skills/judge/analyzers/llm_judge.py` with stdlib-only
+  `AnthropicClient`. Gated by
+  `judge-config.json.llm_second_opinion.enabled` (default `false`).
+  When on, emits `dimensions[dim].llm_score` /
+  `dimensions[dim].llm_justification` alongside the heuristic entries.
+  Transcripts trimmed to 16k chars (~4k tokens) with a head/tail
+  preservation strategy. Sends `task-budgets-2026-03-13` beta header
+  when `budget_tokens` is configured. `tests/test_llm_judge.py` injects
+  a fake client — zero network calls in CI. Failures degrade
+  gracefully (heuristics-only scorecard, stderr warning).
+
+- **A4 — Gemini CLI adapter.** `skills/judge/adapters/gemini_cli.py`
+  handles `parts[]`, flattened `content`, `functionCall`, and
+  `functionResponse` shapes. Registered under `gemini-cli` and `gemini`
+  in the adapter registry. Fixture:
+  `tests/fixtures/gemini-cli.jsonl`. Tests in `test_adapters.py`
+  and `test_adapter_fixtures.py`.
+
+- **A5 — `/judge --watch` live re-scoring.**
+  `skills/judge/scripts/watch.py` polls the scores directory every 2 s
+  (configurable via `--interval`). On change, emits a single-line diff
+  header (`improved X, regressed Y, unchanged Z` + composite delta
+  with ↑/↓/→) and re-renders Verdict Studio. `--once` flag for tests.
+  Slash-command docs updated in `commands/judge.md`.
+  `tests/test_watch.py` covers diff math, run-pass behaviour, and the
+  CLI once-path.
+
+- **A6 — dogfood self-score CI gate.**
+  `.github/workflows/self-score.yml` treats the PR title + body +
+  changed-files list as a synthetic transcript and scores it against
+  the code-review rubric. Fails the job when composite <
+  `VERDICT_PR_THRESHOLD` (default 7.0). Posts the Unicode scorecard as
+  a PR comment via `actions/github-script@v7`; updates in place on
+  subsequent pushes.
+
+### Version bumps
+
+- `plugin.json` · `marketplace.json` · `SKILL.md` → `1.2.0-beta.1`
+- `CHANGELOG.md` — full Added / Changed / Tests / Out-of-scope section
+
+### Tests
+
+| Suite                         | Before | After |
+| ----------------------------- | :----: | :---: |
+| Total unit tests              |  262   |  314  |
+| Benchmark pack cases          |    8   |    8  |
+| `test_schema.py`              |    —   |    7  |
+| `test_llm_judge.py`           |    —   |   24  |
+| `test_watch.py`               |    —   |   12  |
+| Gemini coverage               |    —   |    9  |
+
+All green locally. Shellcheck clean on `hooks/*.sh`. Marketplace
+validator passes.
+
+### Out of scope for this PR
+
+- Rubric marketplace index (P2)
+- Scorecard delta webhook (P2)
+- `verdict` PyPI shim (P2)
+- MLflow integration (future)
+
+### Upgrade notes for consumers
+
+- Scorecard JSON now carries `$schema` and `schemaVersion` at the top.
+  Existing consumers that iterate top-level keys will see two new
+  entries; add them to your allowlist or (better) pin to the schema.
+- `llm_second_opinion` config block is present but disabled. Old
+  configs without the block continue to work; `_llm_second_opinion_config`
+  treats a missing block as disabled without warning.
+- `adapters/` registry now has `gemini-cli` and `gemini` entries. If
+  you vendored the registry, regenerate it.
+
+### Prompt reference
+
+Executes the 2026-04-19 prompt (Thread A only — Thread B was out of
+scope by your decision).

--- a/commands/judge.md
+++ b/commands/judge.md
@@ -1,7 +1,7 @@
 ---
 name: judge
 description: "Evaluate the execution quality of a skill or agent"
-usage: "/judge [skill-name] [--rubric RUBRIC] [--verbose] [--adapter NAME] [--model ID] [--against REF]"
+usage: "/judge [skill-name] [--rubric RUBRIC] [--verbose] [--adapter NAME] [--model ID] [--against REF] [--watch] [--llm-second-opinion]"
 ---
 
 # /judge — Manual Skill Quality Evaluation
@@ -17,9 +17,11 @@ When the user invokes `/judge`, evaluate the most recent skill or agent executio
 - `skill-name` (optional): The name of the skill to judge. If omitted, detect the last skill that ran from the conversation context.
 - `--rubric RUBRIC` (optional): Use a specific rubric file (e.g., `security`, `code-review`). If omitted, auto-detect the best rubric.
 - `--verbose` (optional): Show detailed per-dimension justifications.
-- `--adapter NAME` (optional): Transcript adapter for non-native ecosystems. One of `claude-code`, `cowork`, `openai-compatible`, `codex`, `cursor`, `continue`.
+- `--adapter NAME` (optional): Transcript adapter for non-native ecosystems. One of `claude-code`, `cowork`, `openai-compatible`, `codex`, `cursor`, `continue`, `gemini-cli`.
 - `--model ID` (optional): Model ID override (e.g., `claude-opus-4-7`). When omitted, the model is auto-detected from the transcript and the `tokenizer_baselines` config scales efficiency length thresholds accordingly.
 - `--against REF` (optional): Compare the current scorecard against a previous run of the same skill (`HEAD~1` = penultimate scorecard, numeric index = absolute). Delegates to `skills/judge/scripts/against.py` and exits non-zero on composite regression.
+- `--watch` (optional): Run the live re-scoring daemon in `skills/judge/scripts/watch.py`. Polls the scores directory every 2 s, prints a one-line diff header per change (`improved X, regressed Y, unchanged Z since last run`), and re-emits Verdict Studio to the `--output` HTML path. Pairs with `/scorecard` or `/benchmark` during iterative skill development.
+- `--llm-second-opinion` (optional): Force the opt-in LLM second-opinion analyzer on for this one run even when `llm_second_opinion.enabled = false` in `judge-config.json`. Requires `ANTHROPIC_API_KEY`. See `skills/judge/analyzers/llm_judge.py`.
 
 ## Evaluation Process
 

--- a/judge-config.json
+++ b/judge-config.json
@@ -34,5 +34,10 @@
     "claude-opus-4-7": 1.35,
     "claude-sonnet-4-6": 1.0,
     "claude-haiku-4-5": 1.0
+  },
+  "llm_second_opinion": {
+    "enabled": false,
+    "model": "claude-haiku-4-5",
+    "budget_tokens": null
   }
 }

--- a/schemas/scorecard.v1.schema.json
+++ b/schemas/scorecard.v1.schema.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://verdict.dev/schemas/scorecard.v1.json",
+  "title": "Verdict Scorecard",
+  "description": "Canonical shape of a Verdict scorecard JSON document as emitted by skills/judge/scripts/score.py::save_score. See DEEP_ANALYSIS.md §Schema stability contract for evolution rules.",
+  "type": "object",
+  "required": [
+    "$schema",
+    "schemaVersion",
+    "skill",
+    "timestamp",
+    "composite_score",
+    "grade",
+    "grade_label",
+    "dimensions",
+    "red_flags",
+    "bonuses",
+    "adjustments",
+    "summary",
+    "one_liner",
+    "critical_issues",
+    "recommendations",
+    "rubric_used",
+    "transcript_lines"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "const": "https://verdict.dev/schemas/scorecard.v1.json"
+    },
+    "schemaVersion": {
+      "type": "string",
+      "pattern": "^1\\.\\d+\\.\\d+$",
+      "description": "SemVer. Major = 1 for the lifetime of this schema. Minor bumps are additive-compatible; patch bumps are purely editorial."
+    },
+    "skill": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Name of the evaluated skill or subagent (e.g. 'code-review')."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC 3339 UTC timestamp of scoring (e.g. '2026-04-18T08:27:18Z')."
+    },
+    "composite_score": {
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 10.0,
+      "description": "Final 0–10 composite after red-flag deductions and bonuses."
+    },
+    "raw_composite": {
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 10.0,
+      "description": "Weighted-sum composite BEFORE adjustments. Optional; not emitted by older runs."
+    },
+    "grade": {
+      "type": "string",
+      "enum": ["A+", "A", "A-", "B+", "B", "B-", "C+", "C", "C-", "D", "F"]
+    },
+    "grade_label": {
+      "type": "string",
+      "minLength": 1
+    },
+    "dimensions": {
+      "type": "object",
+      "required": [
+        "correctness",
+        "completeness",
+        "adherence",
+        "actionability",
+        "efficiency",
+        "safety",
+        "consistency"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "correctness":   {"$ref": "#/$defs/dimensionEntry"},
+        "completeness":  {"$ref": "#/$defs/dimensionEntry"},
+        "adherence":     {"$ref": "#/$defs/dimensionEntry"},
+        "actionability": {"$ref": "#/$defs/dimensionEntry"},
+        "efficiency":    {"$ref": "#/$defs/dimensionEntry"},
+        "safety":        {"$ref": "#/$defs/dimensionEntry"},
+        "consistency":   {"$ref": "#/$defs/dimensionEntry"}
+      }
+    },
+    "red_flags": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Auto-deduction triggers (hallucination, contradiction, ignored constraint, placeholder, rm -rf /)."
+    },
+    "bonuses": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Auto-bonus triggers (edge cases, trade-off reasoning, structured output)."
+    },
+    "adjustments": {
+      "type": "object",
+      "required": ["deduction", "bonus"],
+      "additionalProperties": false,
+      "properties": {
+        "deduction": {"type": "number", "minimum": 0.0, "maximum": 2.0},
+        "bonus":     {"type": "number", "minimum": 0.0, "maximum": 1.0}
+      }
+    },
+    "summary":         {"type": "string"},
+    "one_liner":       {"type": "string"},
+    "critical_issues": {"type": "array", "items": {"type": "string"}},
+    "recommendations": {"type": "array", "items": {"type": "string"}},
+    "rubric_used":     {"type": "string", "minLength": 1},
+    "transcript_lines":{"type": "integer", "minimum": 0},
+    "model": {
+      "type": ["string", "null"],
+      "description": "Model ID auto-detected from the transcript (e.g. 'claude-opus-4-7'), or null when none was detected."
+    },
+    "tokenizer_baseline": {
+      "type": "number",
+      "exclusiveMinimum": 0.0,
+      "description": "Multiplier applied to efficiency length thresholds for this model."
+    },
+    "weights_source": {
+      "type": "string",
+      "enum": ["config", "rubric"],
+      "description": "Whether the weights came from the global config or a per-rubric <rubric>.weights.json sidecar."
+    }
+  },
+  "$defs": {
+    "dimensionEntry": {
+      "type": "object",
+      "required": ["score", "weight", "weighted", "justification"],
+      "additionalProperties": true,
+      "properties": {
+        "score":         {"type": "integer", "minimum": 1, "maximum": 10},
+        "weight":        {"type": "number",  "minimum": 0.0, "maximum": 1.0},
+        "weighted":      {"type": "number",  "minimum": 0.0, "maximum": 10.0},
+        "justification": {"type": "string",  "minLength": 1},
+        "llm_score": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 10,
+          "description": "Optional LLM second-opinion score. Present only when llm_second_opinion.enabled=true in judge-config.json. Forward-compatible addition planned for v1.2.0."
+        },
+        "llm_justification": {
+          "type": ["string", "null"],
+          "description": "Justification produced by the LLM second-opinion analyzer. Present alongside llm_score."
+        }
+      }
+    }
+  }
+}

--- a/skills/judge/SKILL.md
+++ b/skills/judge/SKILL.md
@@ -2,7 +2,7 @@
 name: judge
 displayName: "Verdict — Universal Quality Evaluator"
 description: "Evaluates the execution quality of any skill or agent using 7-dimension scoring with configurable rubrics"
-version: "1.1.0"
+version: "1.2.0-beta.1"
 author: "Sattyam Jain"
 autoActivate:
   - "when the user asks to judge, evaluate, score, or rate a skill's output"

--- a/skills/judge/adapters/__init__.py
+++ b/skills/judge/adapters/__init__.py
@@ -19,6 +19,7 @@ from .claude_code import extract_lines as _claude_code_extract
 from .cowork import extract_lines as _cowork_extract
 from .openai_compatible import extract_lines as _openai_compatible_extract
 from .codex import extract_lines as _codex_extract
+from .gemini_cli import extract_lines as _gemini_cli_extract
 
 Adapter = Callable[[str], List[str]]
 
@@ -29,6 +30,8 @@ ADAPTERS: Dict[str, Adapter] = {
     "codex": _codex_extract,
     "cursor": _openai_compatible_extract,
     "continue": _openai_compatible_extract,
+    "gemini-cli": _gemini_cli_extract,
+    "gemini": _gemini_cli_extract,
 }
 
 

--- a/skills/judge/adapters/gemini_cli.py
+++ b/skills/judge/adapters/gemini_cli.py
@@ -1,0 +1,143 @@
+"""Gemini CLI session adapter.
+
+The Gemini CLI (v0.38+) emits sessions as JSONL, one turn per line,
+with shape roughly:
+
+    {"role": "user"|"model"|"tool", "parts": [{"text": "..."}, ...], ...}
+
+Older Gemini CLI builds and some community forks flatten ``parts`` to
+``{"content": "..."}``. Occasional tool invocations land as
+``{"functionCall": {"name": "...", "args": {...}}}`` siblings of
+``parts``.  The adapter handles all three shapes plus a plain-text
+fallback.
+
+References (retrieved 2026-04-19):
+
+- Gemini CLI session format is intentionally OpenAI-chat-adjacent but
+  names the assistant turn ``"model"`` rather than ``"assistant"``.
+  See the Gemini CLI docs' "Saved conversations" section.
+- Function calls follow the Gemini API's ``functionCall`` / ``functionResponse``
+  surface, not OpenAI's ``tool_calls`` envelope.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, List
+
+
+def _extract_parts(parts: Any) -> List[str]:
+    """Gemini messages carry a ``parts`` array of typed parts."""
+    if not isinstance(parts, list):
+        return []
+    out: List[str] = []
+    for part in parts:
+        if isinstance(part, dict):
+            text = part.get("text")
+            if isinstance(text, str) and text:
+                out.append(text)
+            # Newer Gemini builds nest function calls inside parts too.
+            fn = part.get("functionCall") or part.get("function_call")
+            if isinstance(fn, dict):
+                name = fn.get("name")
+                args = fn.get("args") if "args" in fn else fn.get("arguments")
+                if name:
+                    args_s = args if isinstance(args, str) else json.dumps(args or {})
+                    out.append(f"tool_use: {name}({args_s})")
+        elif isinstance(part, str) and part:
+            out.append(part)
+    return out
+
+
+def _extract_message(msg: Any) -> List[str]:
+    if not isinstance(msg, dict):
+        return []
+    out: List[str] = []
+
+    # Shape A: newer — {"role": "...", "parts": [...]}
+    if isinstance(msg.get("parts"), list):
+        out.extend(_extract_parts(msg["parts"]))
+
+    # Shape B: older/flattened — {"role": "...", "content": "..."}
+    content = msg.get("content")
+    if isinstance(content, str) and content:
+        out.append(content)
+    elif isinstance(content, list):
+        out.extend(_extract_parts(content))
+
+    # Shape C: top-level functionCall beside parts/content
+    for fn_key in ("functionCall", "function_call"):
+        fn = msg.get(fn_key)
+        if isinstance(fn, dict):
+            name = fn.get("name")
+            args = fn.get("args") if "args" in fn else fn.get("arguments")
+            if name:
+                args_s = args if isinstance(args, str) else json.dumps(args or {})
+                out.append(f"tool_use: {name}({args_s})")
+
+    # functionResponse from the tool
+    fr = msg.get("functionResponse") or msg.get("function_response")
+    if isinstance(fr, dict):
+        response = fr.get("response")
+        if isinstance(response, (dict, list)):
+            out.append(json.dumps(response))
+        elif isinstance(response, str) and response:
+            out.append(response)
+
+    return out
+
+
+def extract_lines(path: str) -> List[str]:
+    """Return lines from a Gemini CLI session transcript.
+
+    Accepts JSONL (one message per line), a top-level JSON array of
+    messages, or an object with ``messages`` / ``turns`` arrays.
+    Plain-text files are passed through as-is.
+    """
+    source = Path(path)
+    if not source.is_file():
+        return []
+    raw = source.read_text(encoding="utf-8")
+
+    stripped = raw.lstrip()
+    if stripped.startswith("[") or stripped.startswith("{"):
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            data = None
+        if isinstance(data, list):
+            out: List[str] = []
+            for msg in data:
+                out.extend(_extract_message(msg))
+            return out
+        if isinstance(data, dict):
+            messages = data.get("messages") or data.get("turns")
+            if isinstance(messages, list):
+                out: List[str] = []
+                for msg in messages:
+                    out.extend(_extract_message(msg))
+                return out
+
+    # JSONL: one message per line
+    jsonl_out: List[str] = []
+    saw_json = False
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith("{"):
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            saw_json = True
+            jsonl_out.extend(_extract_message(msg))
+    if saw_json:
+        return jsonl_out
+
+    # Plain text fallback
+    return [
+        line.strip()
+        for line in raw.splitlines()
+        if line.strip()
+    ]

--- a/skills/judge/analyzers/__init__.py
+++ b/skills/judge/analyzers/__init__.py
@@ -1,0 +1,17 @@
+"""Pluggable scoring analyzers beyond the heuristic engine.
+
+v1.2.0+ adds ``llm_judge``, an opt-in second-opinion path that calls
+Claude (default ``claude-haiku-4-5``) to produce dimension scores
+alongside the default heuristic output. Gated by
+``judge-config.json.llm_second_opinion.enabled`` — off by default so
+Verdict's offline-first promise is preserved.
+"""
+from __future__ import annotations
+
+from .llm_judge import (
+    AnthropicClient,
+    LLMJudgeError,
+    score_with_llm,
+)
+
+__all__ = ["AnthropicClient", "LLMJudgeError", "score_with_llm"]

--- a/skills/judge/analyzers/llm_judge.py
+++ b/skills/judge/analyzers/llm_judge.py
@@ -1,0 +1,310 @@
+"""Opt-in LLM second-opinion analyzer.
+
+.. warning::
+
+    This consumes tokens. Set a per-request budget via the
+    ``task-budgets-2026-03-13`` beta header (supported by Claude since
+    2026-04-17) so Claude hard-caps its own spend and you don't ship a
+    surprise bill when someone turns this on in CI.
+
+Default is OFF. Enabling it requires two things:
+
+1. ``judge-config.json.llm_second_opinion.enabled = true``
+2. ``ANTHROPIC_API_KEY`` in the environment
+
+When both are set, ``score.py`` calls ``score_with_llm`` after the
+heuristic pass and merges per-dimension scores into the scorecard under
+``dimensions[dim].llm_score`` and ``dimensions[dim].llm_justification``.
+
+The module is stdlib-only: HTTP calls go through ``urllib.request``.
+No ``anthropic`` pip package is imported. Callers who want to inject
+a custom client (mock in tests, hit a proxy in prod) can construct an
+``AnthropicClient`` subclass or any object that implements
+``messages_create(model: str, system: str, prompt: str, max_tokens: int) -> str``.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List, Optional, Protocol, Tuple
+
+__all__ = [
+    "DIMENSIONS",
+    "MAX_TRANSCRIPT_CHARS",
+    "LLMJudgeError",
+    "LLMClient",
+    "AnthropicClient",
+    "score_with_llm",
+    "truncate_transcript",
+    "build_prompt",
+    "parse_scores",
+]
+
+DIMENSIONS: List[str] = [
+    "correctness", "completeness", "adherence", "actionability",
+    "efficiency", "safety", "consistency",
+]
+
+# ~4k tokens ≈ 16k chars (rough; depends on model tokenizer).
+# Leave headroom for the system prompt + rubric criteria so the outgoing
+# request stays under Haiku's 200k context window without contention.
+MAX_TRANSCRIPT_CHARS: int = 16_000
+
+ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
+ANTHROPIC_VERSION = "2023-06-01"
+TASK_BUDGETS_BETA = "task-budgets-2026-03-13"
+
+
+class LLMJudgeError(RuntimeError):
+    """Raised when the LLM call fails in a way the caller should surface."""
+
+
+class LLMClient(Protocol):
+    """Duck-typed client contract.
+
+    Implementations must accept a ``system`` + ``prompt`` pair and
+    return the assistant's text response. Everything else (headers,
+    streaming, retries) is implementation-defined.
+    """
+
+    def messages_create(
+        self,
+        model: str,
+        system: str,
+        prompt: str,
+        max_tokens: int,
+    ) -> str: ...
+
+
+class AnthropicClient:
+    """Minimal stdlib-only Anthropic API client.
+
+    Only implements the single ``messages_create`` call Verdict needs.
+    Adds the ``task-budgets-2026-03-13`` beta header when a budget is
+    configured so Claude self-caps runaway evaluations.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        budget_tokens: Optional[int] = None,
+        timeout: float = 30.0,
+    ) -> None:
+        self.api_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+        if not self.api_key:
+            raise LLMJudgeError(
+                "ANTHROPIC_API_KEY not set; LLM second opinion cannot call the API"
+            )
+        self.budget_tokens = budget_tokens
+        self.timeout = timeout
+
+    def messages_create(
+        self,
+        model: str,
+        system: str,
+        prompt: str,
+        max_tokens: int = 2048,
+    ) -> str:
+        body = {
+            "model": model,
+            "max_tokens": max_tokens,
+            "system": system,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        headers = {
+            "x-api-key": self.api_key,
+            "anthropic-version": ANTHROPIC_VERSION,
+            "content-type": "application/json",
+        }
+        if self.budget_tokens:
+            headers["anthropic-beta"] = TASK_BUDGETS_BETA
+            headers["anthropic-task-budget-tokens"] = str(self.budget_tokens)
+
+        req = urllib.request.Request(
+            ANTHROPIC_MESSAGES_URL,
+            data=json.dumps(body).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                raw = resp.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace") if hasattr(exc, "read") else ""
+            raise LLMJudgeError(f"Anthropic API HTTP {exc.code}: {detail[:400]}")
+        except urllib.error.URLError as exc:
+            raise LLMJudgeError(f"Anthropic API unreachable: {exc}")
+
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise LLMJudgeError(f"Anthropic response was not JSON: {exc}")
+
+        return _extract_text(data)
+
+
+def _extract_text(response: Dict[str, Any]) -> str:
+    """Return the concatenated text blocks from a Claude messages response."""
+    content = response.get("content", [])
+    if not isinstance(content, list):
+        raise LLMJudgeError("Anthropic response missing 'content' array")
+    out: List[str] = []
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "text":
+            text = block.get("text", "")
+            if isinstance(text, str):
+                out.append(text)
+    return "\n".join(out)
+
+
+def truncate_transcript(lines: List[str], max_chars: int = MAX_TRANSCRIPT_CHARS) -> str:
+    """Flatten + trim to ``max_chars``, keeping head and tail context.
+
+    When the transcript is over budget the middle is replaced with a
+    marker that records how many characters were dropped. Keeping both
+    ends preserves the user intent (prompt at the top) and the result
+    (output at the bottom).
+    """
+    joined = "\n".join(lines)
+    if len(joined) <= max_chars:
+        return joined
+    half = max_chars // 2
+    head = joined[:half]
+    tail = joined[-half:]
+    elided = len(joined) - max_chars
+    return f"{head}\n\n... [{elided} chars elided to stay under the {max_chars}-char transcript budget] ...\n\n{tail}"
+
+
+def _rubric_criteria_summary(rubric: Dict[str, Any]) -> str:
+    """Render the rubric's per-dimension criteria as a compact string.
+
+    Accepts either the pre-parsed criteria dict (dimension → criteria
+    string) produced by ``score._parse_rubric_criteria`` or a richer
+    ``{"name": "...", "criteria": {...}}`` envelope.
+    """
+    criteria = rubric.get("criteria") if isinstance(rubric.get("criteria"), dict) else rubric
+    lines: List[str] = []
+    for dim in DIMENSIONS:
+        text = criteria.get(dim) if isinstance(criteria, dict) else None
+        if not text:
+            continue
+        # Keep each dimension's criteria terse — Haiku can re-read the
+        # full rubric file if the maintainer wants to, but we don't
+        # pipe it wholesale through the API call.
+        excerpt = text.strip()
+        if len(excerpt) > 600:
+            excerpt = excerpt[:600] + " ..."
+        lines.append(f"- {dim}: {excerpt}")
+    return "\n".join(lines) if lines else "(no per-dimension criteria provided)"
+
+
+SYSTEM_PROMPT = (
+    "You are Verdict's second-opinion judge. Score the transcript on the "
+    "seven dimensions below, each on a 1-10 integer scale. Reply with a "
+    "single JSON object mapping each dimension name to "
+    '{"score": <int 1-10>, "justification": "<one sentence>"}. '
+    "No prose outside the JSON."
+)
+
+
+def build_prompt(transcript: List[str], rubric: Dict[str, Any]) -> str:
+    """Compose the user-facing prompt for a single evaluation call."""
+    excerpt = truncate_transcript(transcript)
+    criteria = _rubric_criteria_summary(rubric)
+    dims = ", ".join(DIMENSIONS)
+    return (
+        f"Rubric: {rubric.get('name', 'default')}\n"
+        f"Dimensions: {dims}\n\n"
+        f"Per-dimension criteria:\n{criteria}\n\n"
+        f"---BEGIN TRANSCRIPT---\n{excerpt}\n---END TRANSCRIPT---\n\n"
+        f"Return only the JSON object."
+    )
+
+
+_JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def parse_scores(response_text: str) -> Dict[str, Tuple[int, str]]:
+    """Parse the LLM response text into a ``{dim: (score, justification)}`` dict.
+
+    Tolerates: leading/trailing prose, triple-backtick fences, minor
+    trailing commas. Any dimension missing from the response is
+    omitted (caller merges selectively). Scores outside 1-10 are
+    clamped; non-numeric scores are skipped with a warning.
+    """
+    # Strip markdown fences if the model wrapped its output.
+    cleaned = response_text.strip()
+    if cleaned.startswith("```"):
+        cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned)
+        cleaned = re.sub(r"\s*```\s*$", "", cleaned)
+
+    match = _JSON_OBJECT_RE.search(cleaned)
+    if not match:
+        raise LLMJudgeError(f"LLM response did not contain a JSON object: {response_text[:200]!r}")
+    try:
+        data = json.loads(match.group(0))
+    except json.JSONDecodeError as exc:
+        # Second-chance: strip trailing commas (common LLM slop).
+        repaired = re.sub(r",(\s*[}\]])", r"\1", match.group(0))
+        try:
+            data = json.loads(repaired)
+        except json.JSONDecodeError:
+            raise LLMJudgeError(f"LLM response was not valid JSON: {exc}")
+
+    if not isinstance(data, dict):
+        raise LLMJudgeError("LLM response root was not an object")
+
+    out: Dict[str, Tuple[int, str]] = {}
+    for dim in DIMENSIONS:
+        entry = data.get(dim)
+        if not isinstance(entry, dict):
+            continue
+        raw_score = entry.get("score")
+        if isinstance(raw_score, bool) or not isinstance(raw_score, (int, float)):
+            continue
+        score = int(round(raw_score))
+        score = max(1, min(10, score))
+        justification = entry.get("justification", "")
+        if not isinstance(justification, str):
+            justification = str(justification)
+        out[dim] = (score, justification.strip())
+    return out
+
+
+def score_with_llm(
+    transcript: List[str],
+    rubric: Dict[str, Any],
+    model: str = "claude-haiku-4-5",
+    client: Optional[LLMClient] = None,
+    max_response_tokens: int = 2048,
+) -> Dict[str, Tuple[int, str]]:
+    """Return a per-dimension (score, justification) dict from the LLM.
+
+    *transcript*: list of transcript lines as produced by
+        ``score.load_transcript`` (pre-adapter output).
+    *rubric*: either the parsed criteria dict produced by
+        ``score._parse_rubric_criteria`` or a richer envelope with
+        ``{"name": "...", "criteria": {...}}``.
+    *model*: any Claude model ID. Default ``claude-haiku-4-5`` keeps
+        the opt-in second opinion cheap (≈$1/MTok input).
+    *client*: injectable for tests. When ``None``, a default
+        :class:`AnthropicClient` is constructed from
+        ``ANTHROPIC_API_KEY``.
+
+    Raises :class:`LLMJudgeError` on API failures or unparseable
+    responses. The caller (``score.build_scorecard``) is expected to
+    catch that and degrade to heuristics-only.
+    """
+    if client is None:
+        client = AnthropicClient()
+    prompt = build_prompt(transcript, rubric)
+    response_text = client.messages_create(
+        model=model,
+        system=SYSTEM_PROMPT,
+        prompt=prompt,
+        max_tokens=max_response_tokens,
+    )
+    return parse_scores(response_text)

--- a/skills/judge/scripts/score.py
+++ b/skills/judge/scripts/score.py
@@ -1081,9 +1081,85 @@ def _generate_recommendations(dimensions: Dict[str, Dict[str, Any]]) -> List[str
 # Score persistence
 # ---------------------------------------------------------------------------
 
+SCORECARD_SCHEMA_URL: str = "https://verdict.dev/schemas/scorecard.v1.json"
+SCORECARD_SCHEMA_VERSION: str = "1.0.0"
+
+
+def _llm_second_opinion_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the normalised ``llm_second_opinion`` sub-config.
+
+    Defaults: disabled, Haiku 4.5, no explicit budget. Callers should
+    treat a missing or malformed block as "disabled" without warning.
+    """
+    block = config.get("llm_second_opinion") if isinstance(config, dict) else None
+    if not isinstance(block, dict):
+        return {"enabled": False, "model": "claude-haiku-4-5", "budget_tokens": None}
+    return {
+        "enabled": bool(block.get("enabled", False)),
+        "model": str(block.get("model", "claude-haiku-4-5")),
+        "budget_tokens": block.get("budget_tokens"),
+    }
+
+
+def _maybe_llm_second_opinion(
+    config: Dict[str, Any],
+    transcript_lines: List[str],
+    rubric_criteria: Dict[str, str],
+    rubric_name: str,
+    dimensions: Dict[str, Dict[str, Any]],
+    client: Optional[Any] = None,
+) -> None:
+    """Merge LLM second-opinion scores into ``dimensions`` in place.
+
+    No-op when the config block has ``enabled=false`` (the default).
+    Failures (missing API key, HTTP error, unparseable response) are
+    logged to stderr and swallowed — Verdict must stay offline-first,
+    so a busted LLM path can never fail the whole scorecard.
+    """
+    cfg = _llm_second_opinion_config(config)
+    if not cfg["enabled"]:
+        return
+
+    # Local import so the module only pulls llm_judge when actually
+    # needed, keeping cold-start costs (and test import times) down.
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+        from analyzers.llm_judge import (  # type: ignore
+            LLMJudgeError,
+            score_with_llm,
+        )
+    except ImportError as exc:
+        print(f"Warning: LLM second opinion unavailable — {exc}", file=sys.stderr)
+        return
+
+    rubric_envelope = {"name": rubric_name, "criteria": rubric_criteria}
+    try:
+        llm_scores = score_with_llm(
+            transcript=transcript_lines,
+            rubric=rubric_envelope,
+            model=cfg["model"],
+            client=client,
+        )
+    except LLMJudgeError as exc:
+        print(f"Warning: LLM second opinion failed — {exc}", file=sys.stderr)
+        return
+    except Exception as exc:  # pragma: no cover — last-ditch defensive
+        print(f"Warning: LLM second opinion crashed — {exc}", file=sys.stderr)
+        return
+
+    for dim, (score_val, justification) in llm_scores.items():
+        if dim in dimensions:
+            dimensions[dim]["llm_score"] = score_val
+            dimensions[dim]["llm_justification"] = justification
+
 
 def save_score(scorecard: Dict[str, Any], scores_dir: str) -> str:
     """Persist the scorecard as a JSON file in *scores_dir*.
+
+    Injects ``$schema`` and ``schemaVersion`` at the top of every
+    emitted document so downstream consumers can version-pin against
+    ``schemas/scorecard.v1.schema.json``. See DEEP_ANALYSIS.md
+    §Schema stability contract for the compatibility rules.
 
     Returns the path to the saved file.
     """
@@ -1096,8 +1172,20 @@ def save_score(scorecard: Dict[str, Any], scores_dir: str) -> str:
     filename = f"{skill}_{safe_ts}.json"
     filepath = scores_path / filename
 
+    # Emit schema identifiers at the top. Constructing a new dict (rather
+    # than mutating the caller's) keeps insertion order deterministic and
+    # avoids surprising callers that hold a reference to ``scorecard``.
+    versioned: Dict[str, Any] = {
+        "$schema": SCORECARD_SCHEMA_URL,
+        "schemaVersion": SCORECARD_SCHEMA_VERSION,
+    }
+    for key, value in scorecard.items():
+        if key in ("$schema", "schemaVersion"):
+            continue
+        versioned[key] = value
+
     filepath.write_text(
-        json.dumps(scorecard, indent=2, ensure_ascii=False) + "\n",
+        json.dumps(versioned, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
     )
     return str(filepath)
@@ -1116,6 +1204,7 @@ def build_scorecard(
     config_path: Optional[str] = None,
     model: Optional[str] = None,
     adapter: Optional[str] = None,
+    llm_client: Optional[Any] = None,
 ) -> Dict[str, Any]:
     """Build a full scorecard for the given skill execution.
 
@@ -1125,6 +1214,9 @@ def build_scorecard(
     ``adapter`` selects a registered transcript adapter from
     ``skills/judge/adapters`` for non-native formats (codex, cursor,
     continue, openai-compatible, cowork).
+    ``llm_client`` is the optional second-opinion LLM client — injected
+    by tests; when omitted and the config enables the feature, a default
+    :class:`analyzers.llm_judge.AnthropicClient` is constructed.
     """
     # 1. Load inputs
     config = load_config(config_path)
@@ -1153,6 +1245,14 @@ def build_scorecard(
             "weighted": weighted,
             "justification": result["justification"],
         }
+
+    # 2b. Opt-in LLM second opinion (off by default; see
+    # analyzers/llm_judge.py). Mutates `dimensions` in place to add
+    # `llm_score` / `llm_justification` alongside the heuristic entries.
+    _maybe_llm_second_opinion(
+        config, transcript_lines, rubric_criteria, rubric_name, dimensions,
+        client=llm_client,
+    )
 
     # 3. Composite score
     raw_composite = compute_composite(dimensions, weights)

--- a/skills/judge/scripts/watch.py
+++ b/skills/judge/scripts/watch.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Live re-scoring daemon.
+
+Polls ``skills/judge/scores/`` (or any directory) every ``interval``
+seconds via ``os.stat``. When a scorecard's mtime changes:
+
+1. Re-read the scorecard JSON.
+2. Compare each dimension against the previous snapshot.
+3. Emit a single-line diff header + re-render Verdict Studio to
+   ``--output``.
+
+Stdlib-only. No file-system watcher dep, no server loop, no threads
+beyond the main one. Exits on SIGINT.
+
+Usage:
+    python3 skills/judge/scripts/watch.py \\
+      --scores-dir skills/judge/scores \\
+      --output verdict-studio.html \\
+      [--interval 2.0] [--once]
+
+The ``--once`` flag runs a single pass (used by tests); omit it to
+poll until Ctrl-C.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(PROJECT_ROOT))
+import studio  # noqa: E402
+
+# Seven dimensions Verdict actually tracks.
+DIMENSIONS: List[str] = [
+    "correctness", "completeness", "adherence", "actionability",
+    "efficiency", "safety", "consistency",
+]
+
+
+def _load_scorecards(scores_dir: Path) -> Dict[Path, Dict[str, Any]]:
+    """Return every valid scorecard in ``scores_dir`` keyed by path."""
+    out: Dict[Path, Dict[str, Any]] = {}
+    if not scores_dir.is_dir():
+        return out
+    for path in sorted(scores_dir.glob("*.json")):
+        try:
+            out[path] = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+    return out
+
+
+def _mtime_map(scores_dir: Path) -> Dict[Path, float]:
+    if not scores_dir.is_dir():
+        return {}
+    return {p: p.stat().st_mtime for p in scores_dir.glob("*.json")}
+
+
+def _dimension_score(card: Dict[str, Any], dim: str) -> Optional[int]:
+    """Extract an int dimension score or ``None`` if missing/malformed."""
+    entry = card.get("dimensions", {}).get(dim)
+    if not isinstance(entry, dict):
+        return None
+    value = entry.get("score")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return int(value)
+
+
+def diff_scorecards(
+    previous: Optional[Dict[str, Any]],
+    current: Dict[str, Any],
+) -> Tuple[int, int, int]:
+    """Return ``(improved, regressed, unchanged)`` dimension counts."""
+    if previous is None:
+        return 0, 0, len(DIMENSIONS)
+    improved = regressed = unchanged = 0
+    for dim in DIMENSIONS:
+        prev = _dimension_score(previous, dim)
+        curr = _dimension_score(current, dim)
+        if prev is None or curr is None:
+            unchanged += 1
+            continue
+        if curr > prev:
+            improved += 1
+        elif curr < prev:
+            regressed += 1
+        else:
+            unchanged += 1
+    return improved, regressed, unchanged
+
+
+def format_diff_header(
+    skill: str,
+    previous: Optional[Dict[str, Any]],
+    current: Dict[str, Any],
+) -> str:
+    """Render the human-readable diff header printed on each change."""
+    improved, regressed, unchanged = diff_scorecards(previous, current)
+    prev_comp = previous.get("composite_score") if previous else None
+    curr_comp = current.get("composite_score", 0.0)
+    if prev_comp is None:
+        delta_str = f"composite {curr_comp:.2f} (first run)"
+    else:
+        delta = curr_comp - prev_comp
+        arrow = "↑" if delta > 0.05 else ("↓" if delta < -0.05 else "→")
+        delta_str = f"composite {prev_comp:.2f} {arrow} {curr_comp:.2f} ({delta:+.2f})"
+    return (
+        f"[watch] {skill}: improved {improved}, regressed {regressed}, "
+        f"unchanged {unchanged} since last run — {delta_str}"
+    )
+
+
+def run_pass(
+    scores_dir: Path,
+    output: Path,
+    previous_snapshot: Dict[Path, Dict[str, Any]],
+    generated_at: str,
+) -> Tuple[Dict[Path, Dict[str, Any]], List[str]]:
+    """Detect changed scorecards, emit diff headers, re-render Studio.
+
+    Returns (new_snapshot, headers_emitted).
+    """
+    current_snapshot = _load_scorecards(scores_dir)
+    headers: List[str] = []
+    for path, card in current_snapshot.items():
+        prev = previous_snapshot.get(path)
+        if prev == card:
+            continue
+        skill = card.get("skill", path.stem)
+        header = format_diff_header(skill, prev, card)
+        headers.append(header)
+    # Also note any file that vanished between passes.
+    for path in sorted(set(previous_snapshot) - set(current_snapshot)):
+        headers.append(f"[watch] removed: {path.name}")
+
+    if headers:
+        studio.generate(scores_dir, output, generated_at)
+    return current_snapshot, headers
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="verdict-watch")
+    parser.add_argument(
+        "--scores-dir", required=True,
+        help="Directory of persisted scorecard JSON files to watch.",
+    )
+    parser.add_argument(
+        "--output", required=True,
+        help="Path to the Studio HTML file to re-render on every change.",
+    )
+    parser.add_argument(
+        "--interval", type=float, default=2.0,
+        help="Seconds between polls (default: 2.0). Minimum enforced: 0.05.",
+    )
+    parser.add_argument(
+        "--once", action="store_true",
+        help="Run a single pass and exit (used by tests).",
+    )
+    parser.add_argument(
+        "--quiet", action="store_true",
+        help="Suppress diff headers on stdout.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    from datetime import datetime, timezone
+    args = parse_args(argv)
+    scores_dir = Path(args.scores_dir)
+    output = Path(args.output)
+    interval = max(0.05, float(args.interval))
+
+    def _now() -> str:
+        return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    previous_snapshot = _load_scorecards(scores_dir)
+    previous_mtimes = _mtime_map(scores_dir)
+    # Emit the initial Studio render so --output always exists after the
+    # first pass, even if nothing has changed yet.
+    studio.generate(scores_dir, output, _now())
+    if not args.quiet:
+        print(f"[watch] tracking {scores_dir} → {output} (every {interval:.2f}s)")
+
+    if args.once:
+        _snapshot, headers = run_pass(scores_dir, output, previous_snapshot, _now())
+        if not args.quiet:
+            for header in headers:
+                print(header)
+        return 0
+
+    try:
+        while True:
+            time.sleep(interval)
+            current_mtimes = _mtime_map(scores_dir)
+            if current_mtimes == previous_mtimes:
+                continue
+            previous_mtimes = current_mtimes
+            previous_snapshot, headers = run_pass(
+                scores_dir, output, previous_snapshot, _now(),
+            )
+            if not args.quiet:
+                for header in headers:
+                    print(header)
+    except KeyboardInterrupt:
+        if not args.quiet:
+            print("[watch] stopped")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/_schema_validator.py
+++ b/tests/_schema_validator.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Minimal stdlib JSON Schema validator.
+
+Covers only the subset of draft 2020-12 that ``schemas/scorecard.v1.schema.json``
+uses. Keeps the project's stdlib-only pitch intact for contributors who
+don't want ``pip install jsonschema``.
+
+Supported keywords:
+    type (including type arrays with "null"), required, properties,
+    additionalProperties (true/false), patternProperties, enum, const,
+    minimum, maximum, exclusiveMinimum, exclusiveMaximum, minLength,
+    maxLength, minItems, maxItems, pattern, items, $ref (local only,
+    `#/$defs/<name>`), $defs, format ("date-time" validated, others
+    passed through).
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any, Dict, List, Tuple
+
+__all__ = ["SchemaError", "validate"]
+
+
+class SchemaError(AssertionError):
+    """Raised when a document fails schema validation."""
+
+
+def _type_matches(value: Any, expected: str) -> bool:
+    if expected == "null":
+        return value is None
+    if expected == "boolean":
+        return isinstance(value, bool)
+    if expected == "integer":
+        # JSON Schema: integer excludes bool but accepts int.
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "object":
+        return isinstance(value, dict)
+    raise SchemaError(f"unknown type keyword: {expected}")
+
+
+def _resolve(ref: str, root: Dict[str, Any]) -> Dict[str, Any]:
+    if not ref.startswith("#/"):
+        raise SchemaError(f"only local $refs supported: {ref}")
+    node: Any = root
+    for part in ref[2:].split("/"):
+        if not isinstance(node, dict) or part not in node:
+            raise SchemaError(f"unresolved $ref: {ref}")
+        node = node[part]
+    if not isinstance(node, dict):
+        raise SchemaError(f"$ref target is not an object: {ref}")
+    return node
+
+
+def _check_format(value: str, fmt: str, path: str) -> None:
+    if fmt == "date-time":
+        # Accept RFC 3339-ish date-times. Python's fromisoformat is strict
+        # about some things; for a trailing Z we coerce before parsing.
+        candidate = value.replace("Z", "+00:00") if value.endswith("Z") else value
+        try:
+            datetime.fromisoformat(candidate)
+        except ValueError:
+            raise SchemaError(f"{path}: not a valid date-time: {value!r}")
+
+
+def _validate(
+    value: Any,
+    schema: Dict[str, Any],
+    root: Dict[str, Any],
+    path: str,
+    errors: List[str],
+) -> None:
+    if "$ref" in schema:
+        target = _resolve(schema["$ref"], root)
+        _validate(value, target, root, path, errors)
+        return
+
+    if "type" in schema:
+        expected = schema["type"]
+        if isinstance(expected, str):
+            if not _type_matches(value, expected):
+                errors.append(
+                    f"{path}: expected type {expected!r}, got {type(value).__name__}"
+                )
+                return
+        elif isinstance(expected, list):
+            if not any(_type_matches(value, t) for t in expected):
+                errors.append(
+                    f"{path}: expected one of types {expected}, got {type(value).__name__}"
+                )
+                return
+        else:
+            errors.append(f"{path}: 'type' must be a string or list")
+            return
+
+    if "const" in schema and value != schema["const"]:
+        errors.append(f"{path}: const mismatch (expected {schema['const']!r}, got {value!r})")
+
+    if "enum" in schema and value not in schema["enum"]:
+        errors.append(f"{path}: value {value!r} not in enum {schema['enum']}")
+
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if "minimum" in schema and value < schema["minimum"]:
+            errors.append(f"{path}: {value} < minimum {schema['minimum']}")
+        if "maximum" in schema and value > schema["maximum"]:
+            errors.append(f"{path}: {value} > maximum {schema['maximum']}")
+        if "exclusiveMinimum" in schema and value <= schema["exclusiveMinimum"]:
+            errors.append(f"{path}: {value} <= exclusiveMinimum {schema['exclusiveMinimum']}")
+        if "exclusiveMaximum" in schema and value >= schema["exclusiveMaximum"]:
+            errors.append(f"{path}: {value} >= exclusiveMaximum {schema['exclusiveMaximum']}")
+
+    if isinstance(value, str):
+        if "minLength" in schema and len(value) < schema["minLength"]:
+            errors.append(f"{path}: length {len(value)} < minLength {schema['minLength']}")
+        if "maxLength" in schema and len(value) > schema["maxLength"]:
+            errors.append(f"{path}: length {len(value)} > maxLength {schema['maxLength']}")
+        if "pattern" in schema:
+            if re.search(schema["pattern"], value) is None:
+                errors.append(f"{path}: {value!r} does not match pattern {schema['pattern']!r}")
+        if "format" in schema:
+            try:
+                _check_format(value, schema["format"], path)
+            except SchemaError as exc:
+                errors.append(str(exc))
+
+    if isinstance(value, list):
+        if "minItems" in schema and len(value) < schema["minItems"]:
+            errors.append(f"{path}: array length {len(value)} < minItems {schema['minItems']}")
+        if "maxItems" in schema and len(value) > schema["maxItems"]:
+            errors.append(f"{path}: array length {len(value)} > maxItems {schema['maxItems']}")
+        items_schema = schema.get("items")
+        if isinstance(items_schema, dict):
+            for i, item in enumerate(value):
+                _validate(item, items_schema, root, f"{path}[{i}]", errors)
+
+    if isinstance(value, dict):
+        required = schema.get("required", []) or []
+        for key in required:
+            if key not in value:
+                errors.append(f"{path}: missing required property {key!r}")
+        properties = schema.get("properties", {}) or {}
+        for key, sub in properties.items():
+            if key in value:
+                _validate(value[key], sub, root, f"{path}.{key}", errors)
+        additional = schema.get("additionalProperties", True)
+        if additional is False:
+            for key in value:
+                if key not in properties:
+                    errors.append(f"{path}: additional property {key!r} not allowed")
+        elif isinstance(additional, dict):
+            for key, sub_value in value.items():
+                if key in properties:
+                    continue
+                _validate(sub_value, additional, root, f"{path}.{key}", errors)
+
+
+def validate(document: Any, schema: Dict[str, Any]) -> Tuple[bool, List[str]]:
+    """Return (is_valid, errors) for *document* against *schema*.
+
+    Does not raise; collects every mismatch so callers can report them
+    all at once.
+    """
+    errors: List[str] = []
+    _validate(document, schema, schema, "$", errors)
+    return not errors, errors

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -18,6 +18,7 @@ enough to exercise every branch of the corresponding adapter
 | `openai-compatible-tools.json`   | Cursor/Continue  | `openai-compatible` | `tool_calls` flattening         |
 | `codex.md`                       | OpenAI Codex CLI | `codex`             | Markdown-style session          |
 | `codex-sidecar.json`             | OpenAI Codex CLI | `codex`             | JSON sidecar delegates OpenAI   |
+| `gemini-cli.jsonl`               | Gemini CLI       | `gemini-cli`        | parts[] + functionCall/Response |
 
 When an ecosystem changes its format, update the fixture *and* the
 adapter together so the test pins the new behaviour. Never rely on

--- a/tests/fixtures/gemini-cli.jsonl
+++ b/tests/fixtures/gemini-cli.jsonl
@@ -1,0 +1,5 @@
+{"role":"user","parts":[{"text":"/code-review review src/auth/middleware.py"}]}
+{"role":"model","parts":[{"text":"I'll review the auth middleware for security concerns."}]}
+{"role":"model","parts":[{"text":"Found one issue: the JWT verify call skips audience validation."},{"functionCall":{"name":"read_file","args":{"path":"src/auth/middleware.py"}}}]}
+{"role":"tool","functionResponse":{"name":"read_file","response":{"lines":42,"ok":true}}}
+{"role":"model","parts":[{"text":"Confirmed at line 23. Suggest adding aud=[expected] to jwt.decode()."}]}

--- a/tests/fixtures/scorecards/code-review__clean-code-review.json
+++ b/tests/fixtures/scorecards/code-review__clean-code-review.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://verdict.dev/schemas/scorecard.v1.json",
+  "schemaVersion": "1.0.0",
+  "skill": "code-review",
+  "timestamp": "2026-04-19T18:59:38Z",
+  "composite_score": 9.2,
+  "raw_composite": 8.7,
+  "grade": "A",
+  "grade_label": "Excellent",
+  "dimensions": {
+    "correctness": {
+      "score": 10,
+      "weight": 0.25,
+      "weighted": 2.5,
+      "justification": "No error or hallucination signals detected"
+    },
+    "completeness": {
+      "score": 8,
+      "weight": 0.2,
+      "weighted": 1.6,
+      "justification": "Very short transcript — possible incomplete execution"
+    },
+    "adherence": {
+      "score": 9,
+      "weight": 0.15,
+      "weighted": 1.35,
+      "justification": "Rubric criteria available for evaluation context"
+    },
+    "actionability": {
+      "score": 8,
+      "weight": 0.15,
+      "weighted": 1.2,
+      "justification": "Output appears ready to use"
+    },
+    "efficiency": {
+      "score": 8,
+      "weight": 0.1,
+      "weighted": 0.8,
+      "justification": "Efficient execution"
+    },
+    "safety": {
+      "score": 10,
+      "weight": 0.1,
+      "weighted": 1.0,
+      "justification": "No safety concerns detected"
+    },
+    "consistency": {
+      "score": 5,
+      "weight": 0.05,
+      "weighted": 0.25,
+      "justification": "No prior history for comparison (neutral score)"
+    }
+  },
+  "red_flags": [],
+  "bonuses": [
+    "Proactively addresses edge cases",
+    "Provides well-reasoned justifications for choices"
+  ],
+  "adjustments": {
+    "deduction": 0.0,
+    "bonus": 0.5
+  },
+  "summary": "Outstanding execution across all dimensions.",
+  "one_liner": "Excellent Code Review (A) -- top marks across all dimensions",
+  "critical_issues": [],
+  "recommendations": [
+    "Compare with prior executions and maintain quality baselines"
+  ],
+  "rubric_used": "code-review",
+  "transcript_lines": 5,
+  "model": "claude-opus-4-7",
+  "tokenizer_baseline": 1.35,
+  "weights_source": "config"
+}

--- a/tests/fixtures/scorecards/code-review__openai-compatible.json
+++ b/tests/fixtures/scorecards/code-review__openai-compatible.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://verdict.dev/schemas/scorecard.v1.json",
+  "schemaVersion": "1.0.0",
+  "skill": "code-review",
+  "timestamp": "2026-04-19T18:59:38Z",
+  "composite_score": 9.3,
+  "raw_composite": 8.8,
+  "grade": "A",
+  "grade_label": "Excellent",
+  "dimensions": {
+    "correctness": {
+      "score": 10,
+      "weight": 0.25,
+      "weighted": 2.5,
+      "justification": "No error or hallucination signals detected"
+    },
+    "completeness": {
+      "score": 8,
+      "weight": 0.2,
+      "weighted": 1.6,
+      "justification": "Very short transcript — possible incomplete execution"
+    },
+    "adherence": {
+      "score": 9,
+      "weight": 0.15,
+      "weighted": 1.35,
+      "justification": "Rubric criteria available for evaluation context"
+    },
+    "actionability": {
+      "score": 8,
+      "weight": 0.15,
+      "weighted": 1.2,
+      "justification": "No code blocks detected"
+    },
+    "efficiency": {
+      "score": 7,
+      "weight": 0.1,
+      "weighted": 0.7,
+      "justification": "Moderate tool call density (1 calls)"
+    },
+    "safety": {
+      "score": 10,
+      "weight": 0.1,
+      "weighted": 1.0,
+      "justification": "No safety concerns detected"
+    },
+    "consistency": {
+      "score": 9,
+      "weight": 0.05,
+      "weighted": 0.45,
+      "justification": "Highly consistent scores (std_dev=0.00); Historical average: 9.40, latest: 9.40, n=1"
+    }
+  },
+  "red_flags": [],
+  "bonuses": [
+    "Proactively addresses edge cases",
+    "Provides well-reasoned justifications for choices"
+  ],
+  "adjustments": {
+    "deduction": 0.0,
+    "bonus": 0.5
+  },
+  "summary": "Outstanding execution across all dimensions.",
+  "one_liner": "Excellent Code Review (A) -- top marks across all dimensions",
+  "critical_issues": [],
+  "recommendations": [
+    "Reduce unnecessary tool calls and avoid repeated actions"
+  ],
+  "rubric_used": "code-review",
+  "transcript_lines": 5,
+  "model": null,
+  "tokenizer_baseline": 1.0,
+  "weights_source": "config"
+}

--- a/tests/fixtures/scorecards/code-review__safety-discussion.json
+++ b/tests/fixtures/scorecards/code-review__safety-discussion.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://verdict.dev/schemas/scorecard.v1.json",
+  "schemaVersion": "1.0.0",
+  "skill": "code-review",
+  "timestamp": "2026-04-19T18:59:38Z",
+  "composite_score": 9.4,
+  "raw_composite": 8.9,
+  "grade": "A",
+  "grade_label": "Excellent",
+  "dimensions": {
+    "correctness": {
+      "score": 10,
+      "weight": 0.25,
+      "weighted": 2.5,
+      "justification": "No error or hallucination signals detected"
+    },
+    "completeness": {
+      "score": 8,
+      "weight": 0.2,
+      "weighted": 1.6,
+      "justification": "Very short transcript — possible incomplete execution"
+    },
+    "adherence": {
+      "score": 9,
+      "weight": 0.15,
+      "weighted": 1.35,
+      "justification": "Rubric criteria available for evaluation context"
+    },
+    "actionability": {
+      "score": 8,
+      "weight": 0.15,
+      "weighted": 1.2,
+      "justification": "No code blocks detected"
+    },
+    "efficiency": {
+      "score": 8,
+      "weight": 0.1,
+      "weighted": 0.8,
+      "justification": "Efficient execution"
+    },
+    "safety": {
+      "score": 10,
+      "weight": 0.1,
+      "weighted": 1.0,
+      "justification": "No safety concerns detected"
+    },
+    "consistency": {
+      "score": 9,
+      "weight": 0.05,
+      "weighted": 0.45,
+      "justification": "Highly consistent scores (std_dev=0.00); Historical average: 9.20, latest: 9.20, n=1"
+    }
+  },
+  "red_flags": [],
+  "bonuses": [
+    "Proactively addresses edge cases",
+    "Provides well-reasoned justifications for choices"
+  ],
+  "adjustments": {
+    "deduction": 0.0,
+    "bonus": 0.5
+  },
+  "summary": "Outstanding execution across all dimensions.",
+  "one_liner": "Excellent Code Review (A) -- top marks across all dimensions",
+  "critical_issues": [],
+  "recommendations": [],
+  "rubric_used": "code-review",
+  "transcript_lines": 4,
+  "model": "claude-opus-4-7",
+  "tokenizer_baseline": 1.35,
+  "weights_source": "config"
+}

--- a/tests/fixtures/scorecards/debugging__retries-heavy.json
+++ b/tests/fixtures/scorecards/debugging__retries-heavy.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://verdict.dev/schemas/scorecard.v1.json",
+  "schemaVersion": "1.0.0",
+  "skill": "debugging",
+  "timestamp": "2026-04-19T18:59:38Z",
+  "composite_score": 7.4,
+  "raw_composite": 7.4,
+  "grade": "B-",
+  "grade_label": "Satisfactory",
+  "dimensions": {
+    "correctness": {
+      "score": 6,
+      "weight": 0.25,
+      "weighted": 1.5,
+      "justification": "High error density (1 hits)"
+    },
+    "completeness": {
+      "score": 8,
+      "weight": 0.2,
+      "weighted": 1.6,
+      "justification": "Very short transcript — possible incomplete execution"
+    },
+    "adherence": {
+      "score": 9,
+      "weight": 0.15,
+      "weighted": 1.35,
+      "justification": "Rubric criteria available for evaluation context"
+    },
+    "actionability": {
+      "score": 8,
+      "weight": 0.15,
+      "weighted": 1.2,
+      "justification": "No code blocks detected"
+    },
+    "efficiency": {
+      "score": 5,
+      "weight": 0.1,
+      "weighted": 0.5,
+      "justification": "Reasonable tool usage (1 calls); Many retries/repeated actions (13 hits)"
+    },
+    "safety": {
+      "score": 10,
+      "weight": 0.1,
+      "weighted": 1.0,
+      "justification": "No safety concerns detected"
+    },
+    "consistency": {
+      "score": 5,
+      "weight": 0.05,
+      "weighted": 0.25,
+      "justification": "No prior history for comparison (neutral score)"
+    }
+  },
+  "red_flags": [],
+  "bonuses": [],
+  "adjustments": {
+    "deduction": 0.0,
+    "bonus": 0.0
+  },
+  "summary": "Solid execution with minor areas for improvement.",
+  "one_liner": "Good Debugging (B-) -- strong safety, efficiency could improve",
+  "critical_issues": [],
+  "recommendations": [
+    "Reduce unnecessary tool calls and avoid repeated actions",
+    "Compare with prior executions and maintain quality baselines",
+    "Review output for factual errors and validate against expected behavior"
+  ],
+  "rubric_used": "default",
+  "transcript_lines": 9,
+  "model": null,
+  "tokenizer_baseline": 1.0,
+  "weights_source": "config"
+}

--- a/tests/test_adapter_fixtures.py
+++ b/tests/test_adapter_fixtures.py
@@ -88,5 +88,15 @@ class TestCodexSidecarFixture(unittest.TestCase):
         self.assertIn("Benchmark completed", joined)
 
 
+class TestGeminiCliFixture(unittest.TestCase):
+    def test_extracts_every_part(self) -> None:
+        path = str(FIXTURES_DIR / "gemini-cli.jsonl")
+        lines = adapters.get_adapter("gemini-cli")(path)
+        joined = "\n".join(lines)
+        self.assertIn("middleware.py", joined)
+        self.assertIn("audience validation", joined)
+        self.assertTrue(any(line.startswith("tool_use: read_file(") for line in lines))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -172,5 +172,90 @@ class TestCoworkAdapter(unittest.TestCase):
             os.unlink(path)
 
 
+class TestGeminiCliAdapter(unittest.TestCase):
+    def test_registered_under_two_names(self) -> None:
+        self.assertIn("gemini-cli", adapters.list_adapters())
+        self.assertIn("gemini", adapters.list_adapters())
+        self.assertIs(
+            adapters.get_adapter("gemini"),
+            adapters.get_adapter("gemini-cli"),
+        )
+
+    def test_parts_shape(self) -> None:
+        path = _write(
+            '{"role":"user","parts":[{"text":"hello"}]}\n'
+            '{"role":"model","parts":[{"text":"hi"},{"text":"again"}]}\n'
+        )
+        try:
+            lines = adapters.get_adapter("gemini-cli")(path)
+            self.assertEqual(lines, ["hello", "hi", "again"])
+        finally:
+            os.unlink(path)
+
+    def test_content_flattened_shape(self) -> None:
+        path = _write(
+            '{"role":"user","content":"x"}\n'
+            '{"role":"model","content":"y"}\n'
+        )
+        try:
+            lines = adapters.get_adapter("gemini-cli")(path)
+            self.assertEqual(lines, ["x", "y"])
+        finally:
+            os.unlink(path)
+
+    def test_function_call_flattened(self) -> None:
+        path = _write(
+            '{"role":"model","parts":[{"text":"calling search"}],'
+            '"functionCall":{"name":"search","args":{"q":"verdict"}}}\n'
+        )
+        try:
+            lines = adapters.get_adapter("gemini-cli")(path)
+            self.assertIn("calling search", lines)
+            self.assertTrue(any(line.startswith("tool_use: search(") for line in lines))
+        finally:
+            os.unlink(path)
+
+    def test_function_call_inside_parts(self) -> None:
+        path = _write(
+            '{"role":"model","parts":['
+            '{"text":"invoking tool"},'
+            '{"functionCall":{"name":"read_file","args":{"path":"x.py"}}}'
+            ']}\n'
+        )
+        try:
+            lines = adapters.get_adapter("gemini-cli")(path)
+            self.assertIn("invoking tool", lines)
+            self.assertTrue(any(line.startswith("tool_use: read_file(") for line in lines))
+        finally:
+            os.unlink(path)
+
+    def test_top_level_array(self) -> None:
+        payload = (
+            '[{"role":"user","parts":[{"text":"q"}]},'
+            '{"role":"model","parts":[{"text":"a"}]}]'
+        )
+        path = _write(payload, suffix=".json")
+        try:
+            lines = adapters.get_adapter("gemini-cli")(path)
+            self.assertEqual(lines, ["q", "a"])
+        finally:
+            os.unlink(path)
+
+    def test_turns_envelope(self) -> None:
+        payload = '{"turns":[{"role":"user","parts":[{"text":"q"}]}]}'
+        path = _write(payload, suffix=".json")
+        try:
+            lines = adapters.get_adapter("gemini-cli")(path)
+            self.assertEqual(lines, ["q"])
+        finally:
+            os.unlink(path)
+
+    def test_missing_file_returns_empty(self) -> None:
+        self.assertEqual(
+            adapters.get_adapter("gemini-cli")("/tmp/verdict-gemini-missing"),
+            [],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_llm_judge.py
+++ b/tests/test_llm_judge.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Tests for the opt-in LLM second-opinion analyzer.
+
+Uses a mock client so no network calls happen. Exercises:
+  - transcript truncation math
+  - prompt composition (dimension list + rubric criteria inclusion)
+  - response parsing (clean JSON, fenced JSON, trailing commas, prose
+    wrapper)
+  - score clamping (<1 → 1, >10 → 10)
+  - integration through ``score.build_scorecard`` when the config
+    toggle is on, with the client injected
+  - graceful degradation when the LLM call fails
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import patch
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "skills" / "judge"))
+sys.path.insert(0, str(PROJECT_ROOT / "skills" / "judge" / "scripts"))
+
+from analyzers import llm_judge as lj  # noqa: E402
+import score  # noqa: E402
+
+
+class FakeClient:
+    """In-memory LLMClient used by tests. Captures last call for assertions."""
+
+    def __init__(self, response_text: str = "", raises: Optional[Exception] = None):
+        self.response_text = response_text
+        self.raises = raises
+        self.calls: List[Dict[str, Any]] = []
+
+    def messages_create(self, model: str, system: str, prompt: str, max_tokens: int) -> str:
+        self.calls.append({
+            "model": model, "system": system, "prompt": prompt, "max_tokens": max_tokens,
+        })
+        if self.raises:
+            raise self.raises
+        return self.response_text
+
+
+def _canonical_response(score_per_dim: int = 8) -> str:
+    return json.dumps({
+        dim: {"score": score_per_dim, "justification": f"llm view of {dim}"}
+        for dim in lj.DIMENSIONS
+    })
+
+
+class TestTruncateTranscript(unittest.TestCase):
+    def test_under_budget_returns_joined(self) -> None:
+        lines = ["a" * 100, "b" * 100]
+        out = lj.truncate_transcript(lines, max_chars=1000)
+        self.assertEqual(out, "\n".join(lines))
+
+    def test_over_budget_preserves_head_and_tail(self) -> None:
+        lines = ["x" * 10_000] + ["middle"] * 50 + ["y" * 10_000]
+        out = lj.truncate_transcript(lines, max_chars=2_000)
+        self.assertLess(len(out), 3_000)  # ~max_chars + marker overhead
+        self.assertTrue(out.startswith("x"))
+        self.assertTrue(out.rstrip().endswith("y"))
+        self.assertIn("elided", out)
+
+    def test_default_budget_is_16k_chars(self) -> None:
+        self.assertEqual(lj.MAX_TRANSCRIPT_CHARS, 16_000)
+
+
+class TestBuildPrompt(unittest.TestCase):
+    def test_includes_all_dimensions(self) -> None:
+        prompt = lj.build_prompt(["hello"], {"criteria": {}})
+        for dim in lj.DIMENSIONS:
+            self.assertIn(dim, prompt)
+
+    def test_includes_rubric_criteria(self) -> None:
+        rubric = {"name": "security", "criteria": {
+            "safety": "heavy weight on exposed secrets",
+            "correctness": "real vulnerabilities only, no false positives",
+        }}
+        prompt = lj.build_prompt(["x"], rubric)
+        self.assertIn("heavy weight on exposed secrets", prompt)
+        self.assertIn("real vulnerabilities", prompt)
+
+    def test_transcript_excerpted_inside_markers(self) -> None:
+        prompt = lj.build_prompt(["line-one", "line-two"], {"criteria": {}})
+        self.assertIn("---BEGIN TRANSCRIPT---", prompt)
+        self.assertIn("---END TRANSCRIPT---", prompt)
+        self.assertIn("line-one", prompt)
+        self.assertIn("line-two", prompt)
+
+
+class TestParseScores(unittest.TestCase):
+    def test_clean_json(self) -> None:
+        resp = json.dumps({
+            "correctness": {"score": 8, "justification": "ok"},
+            "safety": {"score": 10, "justification": "spotless"},
+        })
+        parsed = lj.parse_scores(resp)
+        self.assertEqual(parsed["correctness"], (8, "ok"))
+        self.assertEqual(parsed["safety"], (10, "spotless"))
+
+    def test_fenced_json_stripped(self) -> None:
+        resp = '```json\n{"correctness": {"score": 7, "justification": "fine"}}\n```'
+        parsed = lj.parse_scores(resp)
+        self.assertEqual(parsed["correctness"], (7, "fine"))
+
+    def test_trailing_commas_repaired(self) -> None:
+        resp = '{"correctness": {"score": 6, "justification": "ok",},}'
+        parsed = lj.parse_scores(resp)
+        self.assertEqual(parsed["correctness"], (6, "ok"))
+
+    def test_prose_wrapper_tolerated(self) -> None:
+        resp = 'Sure! Here you go:\n{"correctness": {"score": 9, "justification": "strong"}}\nCheers.'
+        parsed = lj.parse_scores(resp)
+        self.assertEqual(parsed["correctness"], (9, "strong"))
+
+    def test_scores_clamped_to_range(self) -> None:
+        resp = json.dumps({
+            "correctness": {"score": 42, "justification": "hot"},
+            "safety":      {"score": -5, "justification": "cold"},
+        })
+        parsed = lj.parse_scores(resp)
+        self.assertEqual(parsed["correctness"][0], 10)
+        self.assertEqual(parsed["safety"][0], 1)
+
+    def test_float_scores_rounded_to_int(self) -> None:
+        resp = json.dumps({"correctness": {"score": 7.6, "justification": "near A"}})
+        self.assertEqual(lj.parse_scores(resp)["correctness"][0], 8)
+
+    def test_missing_dimensions_silently_dropped(self) -> None:
+        resp = json.dumps({"correctness": {"score": 8, "justification": "ok"}})
+        parsed = lj.parse_scores(resp)
+        self.assertIn("correctness", parsed)
+        self.assertNotIn("efficiency", parsed)
+
+    def test_non_json_raises(self) -> None:
+        with self.assertRaises(lj.LLMJudgeError):
+            lj.parse_scores("totally not JSON")
+
+    def test_non_object_root_raises(self) -> None:
+        with self.assertRaises(lj.LLMJudgeError):
+            lj.parse_scores("[1, 2, 3]")
+
+
+class TestScoreWithLLM(unittest.TestCase):
+    def test_shape_and_score_range(self) -> None:
+        client = FakeClient(response_text=_canonical_response(score_per_dim=7))
+        result = lj.score_with_llm(
+            transcript=["hello world"],
+            rubric={"name": "default", "criteria": {}},
+            client=client,
+        )
+        self.assertEqual(set(result), set(lj.DIMENSIONS))
+        for dim, (s, _) in result.items():
+            self.assertGreaterEqual(s, 1)
+            self.assertLessEqual(s, 10)
+
+    def test_passes_configured_model(self) -> None:
+        client = FakeClient(response_text=_canonical_response())
+        lj.score_with_llm(
+            transcript=["x"],
+            rubric={"criteria": {}},
+            model="claude-opus-4-7",
+            client=client,
+        )
+        self.assertEqual(client.calls[0]["model"], "claude-opus-4-7")
+
+    def test_failing_client_raises_judge_error(self) -> None:
+        client = FakeClient(raises=lj.LLMJudgeError("rate limited"))
+        with self.assertRaises(lj.LLMJudgeError):
+            lj.score_with_llm(["x"], {"criteria": {}}, client=client)
+
+
+class TestAnthropicClientConstruction(unittest.TestCase):
+    def test_raises_without_api_key(self) -> None:
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}, clear=False):
+            os.environ.pop("ANTHROPIC_API_KEY", None)
+            with self.assertRaises(lj.LLMJudgeError):
+                lj.AnthropicClient()
+
+    def test_accepts_explicit_key(self) -> None:
+        client = lj.AnthropicClient(api_key="sk-ant-test")
+        self.assertEqual(client.api_key, "sk-ant-test")
+
+    def test_budget_tokens_stored(self) -> None:
+        client = lj.AnthropicClient(api_key="sk-ant-test", budget_tokens=1024)
+        self.assertEqual(client.budget_tokens, 1024)
+
+
+class TestBuildScorecardIntegration(unittest.TestCase):
+    """score.build_scorecard must integrate the LLM pass when enabled."""
+
+    def _fixture_transcript(self, tmp: Path) -> Path:
+        path = tmp / "tx.jsonl"
+        path.write_text(
+            '{"role":"user","content":"/code-review review src/auth/middleware.py"}\n'
+            '{"role":"assistant","content":"Looks clean."}\n',
+            encoding="utf-8",
+        )
+        return path
+
+    def _config(self, tmp: Path, enabled: bool) -> Path:
+        cfg = {
+            "auto_judge": {"enabled": True, "threshold": 5.0},
+            "scoring": {"dimensions": {
+                "correctness": 0.25, "completeness": 0.20, "adherence": 0.15,
+                "actionability": 0.15, "efficiency": 0.10, "safety": 0.10,
+                "consistency": 0.05,
+            }},
+            "llm_second_opinion": {
+                "enabled": enabled,
+                "model": "claude-haiku-4-5",
+                "budget_tokens": None,
+            },
+        }
+        path = tmp / "config.json"
+        path.write_text(json.dumps(cfg), encoding="utf-8")
+        return path
+
+    def test_disabled_path_omits_llm_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            card = score.build_scorecard(
+                skill_name="code-review",
+                transcript_path=str(self._fixture_transcript(tmp)),
+                rubric_dir=str(PROJECT_ROOT / "skills" / "judge" / "rubrics"),
+                scores_dir=str(tmp / "scores"),
+                config_path=str(self._config(tmp, enabled=False)),
+            )
+            for dim in card["dimensions"].values():
+                self.assertNotIn("llm_score", dim)
+                self.assertNotIn("llm_justification", dim)
+
+    def test_enabled_path_merges_llm_fields(self) -> None:
+        client = FakeClient(response_text=_canonical_response(score_per_dim=9))
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            card = score.build_scorecard(
+                skill_name="code-review",
+                transcript_path=str(self._fixture_transcript(tmp)),
+                rubric_dir=str(PROJECT_ROOT / "skills" / "judge" / "rubrics"),
+                scores_dir=str(tmp / "scores"),
+                config_path=str(self._config(tmp, enabled=True)),
+                llm_client=client,
+            )
+            self.assertEqual(len(client.calls), 1)
+            for dim in lj.DIMENSIONS:
+                entry = card["dimensions"][dim]
+                self.assertEqual(entry["llm_score"], 9)
+                self.assertIn("llm view of", entry["llm_justification"])
+
+    def test_enabled_path_with_failing_client_degrades_gracefully(self) -> None:
+        client = FakeClient(raises=lj.LLMJudgeError("500 upstream"))
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            card = score.build_scorecard(
+                skill_name="code-review",
+                transcript_path=str(self._fixture_transcript(tmp)),
+                rubric_dir=str(PROJECT_ROOT / "skills" / "judge" / "rubrics"),
+                scores_dir=str(tmp / "scores"),
+                config_path=str(self._config(tmp, enabled=True)),
+                llm_client=client,
+            )
+            # Heuristic scores still present; LLM fields absent.
+            for dim in card["dimensions"].values():
+                self.assertIn("score", dim)
+                self.assertNotIn("llm_score", dim)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Validate every persisted scorecard fixture against scorecard.v1.schema.json.
+
+This is the compatibility gate for the Verdict scorecard JSON shape.
+When you intentionally evolve the schema, bump ``schemaVersion``, add
+the new fields under ``$defs`` or at the top level, and regenerate the
+fixtures. See DEEP_ANALYSIS.md §Schema stability contract.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = PROJECT_ROOT / "schemas" / "scorecard.v1.schema.json"
+FIXTURES_DIR = PROJECT_ROOT / "tests" / "fixtures" / "scorecards"
+SCRIPTS_DIR = PROJECT_ROOT / "skills" / "judge" / "scripts"
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _schema_validator import validate  # noqa: E402
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+import score  # noqa: E402
+
+
+def _load_schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+class TestSchemaFileWellFormed(unittest.TestCase):
+    def test_schema_file_parses(self) -> None:
+        schema = _load_schema()
+        self.assertEqual(
+            schema.get("$id"),
+            "https://verdict.dev/schemas/scorecard.v1.json",
+        )
+        self.assertEqual(
+            schema.get("$schema"),
+            "https://json-schema.org/draft/2020-12/schema",
+        )
+        self.assertIn("dimensions", schema["properties"])
+
+    def test_schema_requires_schema_and_version(self) -> None:
+        schema = _load_schema()
+        self.assertIn("$schema", schema["required"])
+        self.assertIn("schemaVersion", schema["required"])
+
+
+class TestPersistedFixtures(unittest.TestCase):
+    """Every scorecard in tests/fixtures/scorecards/ must validate."""
+
+    def test_fixtures_directory_populated(self) -> None:
+        self.assertTrue(FIXTURES_DIR.is_dir())
+        fixtures = list(FIXTURES_DIR.glob("*.json"))
+        self.assertGreaterEqual(
+            len(fixtures),
+            3,
+            "expected at least 3 persisted scorecard fixtures; regenerate them",
+        )
+
+    def test_every_fixture_validates(self) -> None:
+        schema = _load_schema()
+        failures = []
+        for path in sorted(FIXTURES_DIR.glob("*.json")):
+            try:
+                document = json.loads(path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError as exc:
+                failures.append(f"{path.name}: malformed JSON — {exc}")
+                continue
+            ok, errors = validate(document, schema)
+            if not ok:
+                failures.append(f"{path.name}:\n  " + "\n  ".join(errors))
+        self.assertEqual(failures, [], "schema violations:\n" + "\n".join(failures))
+
+    def test_every_fixture_has_schema_fields_at_top(self) -> None:
+        """$schema and schemaVersion must be present and correct."""
+        for path in sorted(FIXTURES_DIR.glob("*.json")):
+            document = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                document.get("$schema"),
+                "https://verdict.dev/schemas/scorecard.v1.json",
+                f"{path.name}: missing or wrong $schema",
+            )
+            self.assertEqual(
+                document.get("schemaVersion"),
+                "1.0.0",
+                f"{path.name}: missing or wrong schemaVersion",
+            )
+
+
+class TestPersistInjection(unittest.TestCase):
+    """save_score must inject $schema and schemaVersion on every write."""
+
+    def test_save_score_injects_schema_fields(self) -> None:
+        import tempfile
+        scorecard = {
+            "skill": "test",
+            "timestamp": "2026-04-19T00:00:00Z",
+            "composite_score": 8.0,
+            "raw_composite": 8.0,
+            "grade": "B+",
+            "grade_label": "Good",
+            "dimensions": {
+                "correctness":   {"score": 8, "weight": 0.25, "weighted": 2.0, "justification": "ok"},
+                "completeness":  {"score": 8, "weight": 0.20, "weighted": 1.6, "justification": "ok"},
+                "adherence":     {"score": 8, "weight": 0.15, "weighted": 1.2, "justification": "ok"},
+                "actionability": {"score": 8, "weight": 0.15, "weighted": 1.2, "justification": "ok"},
+                "efficiency":    {"score": 8, "weight": 0.10, "weighted": 0.8, "justification": "ok"},
+                "safety":        {"score": 8, "weight": 0.10, "weighted": 0.8, "justification": "ok"},
+                "consistency":   {"score": 5, "weight": 0.05, "weighted": 0.25, "justification": "ok"},
+            },
+            "red_flags": [],
+            "bonuses": [],
+            "adjustments": {"deduction": 0.0, "bonus": 0.0},
+            "summary": "s",
+            "one_liner": "ok",
+            "critical_issues": [],
+            "recommendations": [],
+            "rubric_used": "default",
+            "transcript_lines": 10,
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            path = score.save_score(scorecard, tmp)
+            document = json.loads(Path(path).read_text(encoding="utf-8"))
+        self.assertEqual(document["$schema"], score.SCORECARD_SCHEMA_URL)
+        self.assertEqual(document["schemaVersion"], score.SCORECARD_SCHEMA_VERSION)
+        # Keys must appear at the top of the emitted document (JSON object
+        # key order is preserved by Python's json module).
+        keys = list(document.keys())
+        self.assertEqual(keys[0], "$schema")
+        self.assertEqual(keys[1], "schemaVersion")
+
+    def test_save_score_idempotent_when_fields_preexist(self) -> None:
+        """If the caller already added $schema/schemaVersion, don't duplicate."""
+        import tempfile
+        scorecard = {
+            "$schema": "https://example.com/other.json",
+            "schemaVersion": "2.0.0",
+            "skill": "x", "timestamp": "2026-04-19T00:00:00Z",
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            path = score.save_score(scorecard, tmp)
+            document = json.loads(Path(path).read_text(encoding="utf-8"))
+            # Raw read has to happen before the tempdir is torn down.
+            raw = Path(path).read_text(encoding="utf-8")
+        # save_score overrides with its own canonical values.
+        self.assertEqual(document["$schema"], score.SCORECARD_SCHEMA_URL)
+        self.assertEqual(document["schemaVersion"], score.SCORECARD_SCHEMA_VERSION)
+        # No duplicate keys in the persisted JSON text.
+        self.assertEqual(raw.count('"$schema"'), 1)
+        self.assertEqual(raw.count('"schemaVersion"'), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Tests for skills/judge/scripts/watch.py live re-scoring."""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Dict
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "skills" / "judge" / "scripts"))
+
+import watch  # noqa: E402
+
+
+def _card(
+    skill: str,
+    timestamp: str,
+    composite: float,
+    dim_scores: Dict[str, int],
+) -> Dict[str, Any]:
+    return {
+        "$schema": "https://verdict.dev/schemas/scorecard.v1.json",
+        "schemaVersion": "1.0.0",
+        "skill": skill,
+        "timestamp": timestamp,
+        "composite_score": composite,
+        "grade": "B+",
+        "dimensions": {dim: {"score": dim_scores.get(dim, 8)} for dim in watch.DIMENSIONS},
+    }
+
+
+def _write(path: Path, card: Dict[str, Any]) -> None:
+    path.write_text(json.dumps(card), encoding="utf-8")
+
+
+class TestDiffScorecards(unittest.TestCase):
+    def test_first_run_counts_all_unchanged(self) -> None:
+        card = _card("x", "2026-04-19T00:00:00Z", 8.0, {})
+        self.assertEqual(watch.diff_scorecards(None, card), (0, 0, len(watch.DIMENSIONS)))
+
+    def test_improvement_detected(self) -> None:
+        prev = _card("x", "2026-04-19T00:00:00Z", 7.0, {"correctness": 7})
+        curr = _card("x", "2026-04-19T00:00:01Z", 8.0, {"correctness": 9})
+        improved, regressed, _unchanged = watch.diff_scorecards(prev, curr)
+        self.assertEqual(improved, 1)
+        self.assertEqual(regressed, 0)
+
+    def test_regression_detected(self) -> None:
+        prev = _card("x", "2026-04-19T00:00:00Z", 8.0, {"safety": 10})
+        curr = _card("x", "2026-04-19T00:00:01Z", 7.0, {"safety": 6})
+        improved, regressed, _ = watch.diff_scorecards(prev, curr)
+        self.assertEqual(improved, 0)
+        self.assertEqual(regressed, 1)
+
+    def test_missing_dimensions_treated_unchanged(self) -> None:
+        prev = {"dimensions": {}}
+        curr = _card("x", "2026-04-19T00:00:01Z", 8.0, {})
+        improved, regressed, unchanged = watch.diff_scorecards(prev, curr)
+        self.assertEqual((improved, regressed), (0, 0))
+        self.assertEqual(unchanged, len(watch.DIMENSIONS))
+
+
+class TestFormatDiffHeader(unittest.TestCase):
+    def test_first_run_prints_composite_only(self) -> None:
+        card = _card("code-review", "2026-04-19T00:00:00Z", 8.42, {})
+        text = watch.format_diff_header("code-review", None, card)
+        self.assertIn("code-review", text)
+        self.assertIn("first run", text)
+        self.assertIn("8.42", text)
+
+    def test_improvement_header_uses_up_arrow(self) -> None:
+        prev = _card("x", "2026-04-19T00:00:00Z", 7.0, {})
+        curr = _card("x", "2026-04-19T00:00:01Z", 8.5, {})
+        text = watch.format_diff_header("x", prev, curr)
+        self.assertIn("↑", text)
+        self.assertIn("+1.50", text)
+
+    def test_regression_header_uses_down_arrow(self) -> None:
+        prev = _card("x", "2026-04-19T00:00:00Z", 9.0, {"correctness": 9})
+        curr = _card("x", "2026-04-19T00:00:01Z", 7.5, {"correctness": 6})
+        text = watch.format_diff_header("x", prev, curr)
+        self.assertIn("↓", text)
+        self.assertIn("regressed 1", text)
+
+
+class TestRunPass(unittest.TestCase):
+    def test_emits_header_on_first_appearance(self) -> None:
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            (tmp / "scores").mkdir()
+            _write(tmp / "scores" / "x_a.json",
+                   _card("x", "2026-04-19T00:00:00Z", 8.0, {}))
+            snapshot, headers = watch.run_pass(
+                tmp / "scores", tmp / "out.html", {}, "2026-04-19 00:00 UTC",
+            )
+            self.assertEqual(len(headers), 1)
+            self.assertIn("first run", headers[0])
+            self.assertTrue((tmp / "out.html").is_file())
+            self.assertEqual(len(snapshot), 1)
+
+    def test_no_change_no_header(self) -> None:
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            scores = tmp / "scores"
+            scores.mkdir()
+            card = _card("x", "2026-04-19T00:00:00Z", 8.0, {})
+            _write(scores / "x_a.json", card)
+            snapshot = {scores / "x_a.json": card}
+            _s2, headers = watch.run_pass(scores, tmp / "out.html", snapshot, "ts")
+            self.assertEqual(headers, [])
+
+    def test_change_triggers_header_and_studio_render(self) -> None:
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            scores = tmp / "scores"
+            scores.mkdir()
+            older = _card("x", "2026-04-19T00:00:00Z", 7.0, {"correctness": 7})
+            newer = _card("x", "2026-04-19T00:00:01Z", 8.4, {"correctness": 9})
+            _write(scores / "x_a.json", older)
+            snapshot = {scores / "x_a.json": older}
+            _write(scores / "x_a.json", newer)
+            output = tmp / "out.html"
+            _s2, headers = watch.run_pass(scores, output, snapshot, "ts")
+            self.assertEqual(len(headers), 1)
+            self.assertIn("↑", headers[0])
+            self.assertTrue(output.is_file())
+
+    def test_removed_file_noted(self) -> None:
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            scores = tmp / "scores"
+            scores.mkdir()
+            card = _card("x", "2026-04-19T00:00:00Z", 8.0, {})
+            previous = {scores / "deleted.json": card}
+            _s2, headers = watch.run_pass(scores, tmp / "out.html", previous, "ts")
+            self.assertTrue(any("removed" in h for h in headers))
+
+
+class TestCliOncePath(unittest.TestCase):
+    def test_once_exits_zero_and_writes_output(self) -> None:
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            scores = tmp / "scores"
+            scores.mkdir()
+            _write(scores / "x_a.json", _card("x", "2026-04-19T00:00:00Z", 8.0, {}))
+            output = tmp / "out.html"
+            rc = watch.main([
+                "--scores-dir", str(scores),
+                "--output", str(output),
+                "--once", "--quiet",
+            ])
+            self.assertEqual(rc, 0)
+            self.assertTrue(output.is_file())
+            self.assertIn("Verdict Studio", output.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Executes Thread A of the 2026-04-19 prompt. Commit `0b225cb` stacks
ahead of `main`. Stop here for v1.1.1 scope; v1.2.0 (N1–N8) stacks in
a separate PR against this branch.

Tracks: #3

### A1 — `schemas/scorecard.v1.schema.json` + `$schema` / `schemaVersion`

- Canonical JSON Schema (draft 2020-12) at `schemas/scorecard.v1.schema.json`.
- `save_score` unconditionally injects `$schema` and `schemaVersion`
  at the top of every persisted scorecard. Idempotent when callers
  pre-populate.
- Four committed fixtures under `tests/fixtures/scorecards/`.
- Stdlib-only validator (`tests/_schema_validator.py`) so contributors
  don't need `pip install jsonschema`.
- `DEEP_ANALYSIS.md §14 Schema stability contract` documents SemVer
  rules + deprecation window.

### A2 — issue hygiene

- #2 closed with a v1.1.0 completeness summary.
- #3 opened for v1.2.0 tracking.

### A3 — opt-in LLM second-opinion analyzer

- `skills/judge/analyzers/llm_judge.py` — stdlib-only
  `urllib.request` client, no `anthropic` package.
- Gated by `judge-config.json.llm_second_opinion.enabled` (default
  `false`).
- Transcripts capped at 16k chars with head/tail preservation.
- Failures degrade gracefully (heuristics-only, stderr warning).

### A4 — Gemini CLI adapter

- `skills/judge/adapters/gemini_cli.py` handles `parts[]`, flattened
  `content`, `functionCall`, `functionResponse` shapes.
- Registered under `gemini-cli` and `gemini`.

### A5 — `/judge --watch`

- `skills/judge/scripts/watch.py` polls every 2 s, emits diff headers
  (`improved X, regressed Y, unchanged Z since last run`),
  re-renders Verdict Studio.

### A6 — dogfood self-score CI gate

- `.github/workflows/self-score.yml` scores PR metadata against the
  code-review rubric, fails below `VERDICT_PR_THRESHOLD` (default
  7.0), posts the scorecard as a PR comment.

### Tests

- 262 → 314 (+52). Benchmark pack 8/8. Marketplace validator clean.

### Hard constraints honoured

- Offline-first preserved — LLM judge default off.
- No new non-stdlib runtime deps.
- No secrets in fixtures.