### PR TITLE
v1.3.3 — docs(readme): sync architecture tree, rubric count, tracker note

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "verdict",
       "source": "./",
       "description": "Auto-evaluates skill and agent execution quality with 7-dimension scoring, configurable rubrics, and dual-mode operation.",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "category": "quality-assurance",
       "tags": ["judge", "evaluation", "quality", "scoring", "LLM-as-judge"],
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verdict",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "displayName": "Verdict — Universal Skill & Agent Quality Judge",
   "description": "The first universal judge for Claude Code & Cowork. Auto-evaluates skill and agent execution quality with 7-dimension scoring, configurable rubrics, and dual-mode operation (auto hooks + manual /judge command).",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 2026-04-26
+
+Docs-only patch. Brings `README.md` back into sync with the actual
+repo state after three quick releases (v1.3.0 / v1.3.1 / v1.3.2)
+in three days. No code changes; 619 tests green.
+
+### Changed
+
+- `README.md` "Why Verdict" comparison table: rubric count
+  `(11)` → `(18)`.
+- `README.md` Architecture tree:
+  - Adapters list expanded from 4 to all 9 (`gemini_cli`,
+    `gemini_deep_research`, `mlflow_trace`, `inspect_ai_log`,
+    `terminal_bench` were missing).
+  - Scripts list expanded from 5 to all 8 (`compare.py`,
+    `explain.py`, `watch.py` were missing).
+  - New `integrations/`, `exporters/`, `analyzers/` subtrees added
+    (lighteval shim, Cloudflare AI Gateway, OpenAI Evals exporter,
+    LLM second-opinion).
+  - Rubrics comment: `11 + security.weights.json` → `18 rubrics +
+    5 weight-override sidecars`.
+  - `commands/` line gains `/compare`.
+  - `scripts/` (top-level) gains `sandbox_caps_check.py`.
+- `README.md` Roadmap section: removed stale reference to "open
+  tracking issue: #2" (issue #2 was the v1.1.0 tracker, closed
+  long ago). Replaced with a pointer to the latest release and a
+  one-line note on the per-cycle tracker pattern.
+- Plugin / marketplace version → `1.3.3`.
+
 ## [1.3.2] - 2026-04-26
 
 Patch release. New adapter, EXPERIMENTAL clinical rubric, two

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ workaround (GH #39400), see [INSTALL-COWORK.md](INSTALL-COWORK.md).
 | Runs inside Claude Code    | ✓       | ✗                               | ✗                    | ✗                |
 | Offline (no LLM call)      | ✓       | ✗                               | optional             | ✗                |
 | Zero config for first score| ✓       | ✗                               | ✗                    | ✗                |
-| Per-domain rubrics         | ✓ (11)  | via code                        | via YAML             | via code         |
+| Per-domain rubrics         | ✓ (18)  | via code                        | via YAML             | via code         |
 | Cross-ecosystem transcripts| ✓       | traces only                     | provider-flex        | LangChain-first  |
 | Pip install / deps         | stdlib  | SDK + network                   | SDK                  | SDK + account    |
 | Per-rubric weight override | ✓       | ✗                               | ✗                    | ✗                |
@@ -202,29 +202,46 @@ at 0.35, correctness at 0.20.
   marketplace.json         # Marketplace listing
 skills/judge/
   SKILL.md                 # Core skill definition
+  SKILL-judge-explain.md   # /judge --explain output schema
   scripts/
     score.py               # Scoring engine
     report.py              # Scorecard reporter
     benchmark.py           # Benchmark comparator
     against.py             # /judge --against delta
+    compare.py             # /compare two-file diff with regression narrative
+    explain.py             # /judge --explain Markdown / JSON exporter
     studio.py              # Local HTML dashboard
+    watch.py               # /judge --watch live re-scoring daemon
   adapters/
     claude_code.py         # Native JSONL (default)
     cowork.py              # Claude Cowork sessions
     openai_compatible.py   # Cursor / Continue / generic
     codex.py               # OpenAI Codex CLI
-  rubrics/                 # 11 domain rubrics + security.weights.json
+    gemini_cli.py          # Gemini CLI sessions
+    gemini_deep_research.py# Gemini 3.1 Pro Deep Research / Deep Research Max
+    mlflow_trace.py        # MLflow Trace JSON exports (with OTel GenAI semconv)
+    inspect_ai_log.py      # UK AISI inspect_ai 0.3.x evaluation logs
+    terminal_bench.py      # Terminal-Bench shell-task trajectories
+  integrations/
+    lighteval_shim.py      # LightEval metric shim (lazy-imports lighteval)
+    cloudflare_ai_gateway.py # Cloudflare AI Gateway eval-webhook adapter
+  exporters/
+    openai_evals.py        # Verdict → OpenAI Model Spec Evals JSON
+  analyzers/
+    llm_judge.py           # Opt-in second-opinion (Claude API + cache_control)
+  rubrics/                 # 18 rubrics + 5 weight-override sidecars
   scores/                  # Persisted JSON scorecards
   references/              # Scoring methodology + benchmark standards
 agents/judge-agent.md
 hooks/
   hooks.json               # Stop / SubagentStop / StopFailure
   common.sh, judge-on-stop.sh, judge-on-subagent-stop.sh, judge-on-stop-failure.sh
-commands/                  # /judge, /scorecard, /benchmark, /judge-config, /against
+commands/                  # /judge, /scorecard, /benchmark, /judge-config, /against, /compare
 scripts/
   validate_marketplace.py  # April 2026 schema validator
   install_rubric.py        # Fetch + validate community rubrics
   benchmark_pack.py        # Regression gate for CI
+  sandbox_caps_check.py    # CLAUDE_SANDBOX_CAPS declaration check (CI)
 benchmarks/
   manifest.json + corpus/  # Curated cases
 routines/
@@ -294,8 +311,10 @@ shellcheck hooks/*.sh                         # hook-script lint
 
 ## Roadmap
 
-See [ROADMAP_2026.md](ROADMAP_2026.md) for the 90-day plan. Open
-tracking issue: #2.
+See [ROADMAP_2026.md](ROADMAP_2026.md) for the 90-day plan. Latest
+release: [v1.3.2](https://github.com/sattyamjjain/verdict/releases/tag/v1.3.2).
+No open tracker issues — each cycle's scope is tracked in a fresh
+issue, opened when the cycle starts and closed at release.
 
 ## Contributing
 


### PR DESCRIPTION
Docs-only patch. Brings README back into sync after the v1.3.0 / v1.3.1 / v1.3.2 burst left it claiming a 4-adapter / 11-rubric / 5-script repo when v1.3.2 actually shipped 9 / 18 / 8.

## Concrete drift fixed

| Line | Stale claim | Reality |
|---|---|---|
| 43 | `Per-domain rubrics ✓ (11)` | 18 |
| 205-210 | 5 scripts | 8 (also `compare.py`, `explain.py`, `watch.py`) |
| 213-215 | 4 adapters | 9 (also `gemini_cli`, `gemini_deep_research`, `mlflow_trace`, `inspect_ai_log`, `terminal_bench`) |
| 216 | `11 rubrics + security.weights.json` | 18 rubrics + 5 weight sidecars |
| 223 | `commands/` omits `/compare` | `/compare` exists |
| 297 | `Open tracking issue: #2` | #2 closed (was v1.1.0); 0 open trackers |

Also added `integrations/`, `exporters/`, `analyzers/` subtrees and `scripts/sandbox_caps_check.py` to the architecture diagram.

## Tests

- 619 tests green (no code changes)
- No new runtime deps
- Marketplace + plugin → 1.3.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)