### PR TITLE
docs(readme): sync rubric count and ship-readiness to v1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,17 @@ workaround (GH #39400), see [INSTALL-COWORK.md](INSTALL-COWORK.md).
   Terminal-Bench, and Browser Harness (browser-use) traces with a
   single `--adapter` flag. Auto-detection by confidence-score
   dispatch (the highest-scoring adapter wins).
-- **23 domain rubrics + compliance pack + benchmark / commerce /
-  security pack.** Eleven everyday rubrics (code-review, security,
-  devops, data-analysis, frontend-design, testing, documentation,
-  content-writing, research, default, custom-template); compliance
-  pack (Aider polyglot, Skill compliance, Model Spec compliance,
-  SWE-bench Pro with contamination penalty, Terminal-Bench, OWASP
-  MCP Top 10 beta, EXPERIMENTAL clinical agentic-workflow); plus
-  the v1.4.0 pack: Project Deal commerce, Agentic SAST + Brier
-  calibration, Function-hijacking robustness, GPT-5.5 differential
-  (paired baseline), browser-agent.
+- **24 domain rubrics + compliance pack + benchmark / commerce /
+  security / ship-readiness pack.** Eleven everyday rubrics (code-
+  review, security, devops, data-analysis, frontend-design, testing,
+  documentation, content-writing, research, default, custom-template);
+  compliance pack (Aider polyglot, Skill compliance, Model Spec
+  compliance, SWE-bench Pro with contamination penalty, Terminal-
+  Bench, OWASP MCP Top 10 beta, EXPERIMENTAL clinical agentic-
+  workflow); the v1.4.0 pack (Project Deal commerce, Agentic SAST +
+  Brier calibration, Function-hijacking robustness, GPT-5.5
+  differential (paired baseline), browser-agent); and the v1.4.1
+  release-readiness rubric (ship-readiness with seven binary floors).
 - **Model-aware efficiency.** Opus 4.7's new tokenizer (~35% more
   tokens) doesn't silently penalise its longer outputs — length
   thresholds scale by a per-model baseline.


### PR DESCRIPTION
## Summary

The v1.4.1 ship-readiness rubric was added to the Compliance rubrics table and the architecture tree at release, but the Features bullet still claimed "23 domain rubrics" and didn't mention ship-readiness in the pack listing.

- Bumps "23 domain rubrics" → "24 domain rubrics" in the Features section
- Adds ship-readiness to the v1.4.1 pack listing alongside the v1.4.0 pack

## Test plan

- [x] Rubric count on disk = 24 (verified via `ls skills/judge/rubrics/*.md | grep -v .example.md | wc -l`)
- [x] All other README references already correct (compliance table line 173, architecture tree line 247, comparison table line 43)

🤖 Generated with [Claude Code](https://claude.com/claude-code)