### PR TITLE
docs(readme): complete compliance table with skill-compliance + terminal-bench

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ Verdict's coverage.
 | `model-spec-compliance`       | OpenAI Model Spec Evals                    | Stable (1-7 scale, mapped onto Verdict 1-10) |
 | `swe-bench-pro`               | SWE-bench Pro                              | Stable (contamination-resistant successor to Verified) |
 | `code-review-aider-polyglot`  | Aider polyglot benchmark                   | Stable                                |
+| `terminal-bench`              | Terminal-Bench shell-task trajectory eval  | Stable                                |
+| `skill-compliance`            | MLflow skill-compliance evaluation         | Stable (mirrors MLflow's offline)     |
 | `ship-readiness`              | Verdict release-readiness composite        | Stable (binary floors via the rubric weights sidecar — `ship_floor_*` keys configurable per deployment) |
 
 Beta and experimental rubrics carry a moving-target risk — the


### PR DESCRIPTION
## Summary

The Compliance rubrics table had **11 rows** but disk has **13 compliance-style rubrics**. Both `skill-compliance` and `terminal-bench` shipped in v1.3.0 and are mentioned in the Features prose (lines 70–71) but never had table rows. Pre-existing drift surfaced during the v1.4.1 README sync audit.

After this PR the table contains all 13 compliance/benchmark rubrics on disk.

## Test plan

- [x] Disk: `ls skills/judge/rubrics/{skill-compliance,terminal-bench}.md` both exist
- [x] Both rubrics carry `source_signal` headers (MLflow blog + llm-stats Terminal-Bench page)
- [x] No other rubrics on disk are missing from the compliance table

🤖 Generated with [Claude Code](https://claude.com/claude-code)