### PR TITLE
chore: v2.0.1 release-tag sync — bump manifest + SKILL.md frontmatter; refresh README release anchor; add Claude Code release audit comment to validate_marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "verdict",
       "source": "./",
       "description": "Auto-evaluates skill and agent execution quality with 7-dimension scoring, configurable rubrics, and dual-mode operation.",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "category": "quality-assurance",
       "tags": ["judge", "evaluation", "quality", "scoring", "LLM-as-judge"],
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verdict",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "displayName": "Verdict — Universal Skill & Agent Quality Judge",
   "description": "The first universal judge for Claude Code & Cowork. Auto-evaluates skill and agent execution quality with 7-dimension scoring, configurable rubrics, and dual-mode operation (auto hooks + manual /judge command).",
   "author": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
         run: python3 -m unittest discover tests/ -v
       - name: Validate marketplace.json
         run: python3 scripts/validate_marketplace.py
+      - name: README release anchor matches CHANGELOG
+        run: python3 scripts/check_readme_release_anchor.py
       - name: Benchmark pack (regression gate)
         run: python3 scripts/benchmark_pack.py
 

--- a/README.md
+++ b/README.md
@@ -279,9 +279,15 @@ shellcheck hooks/*.sh                         # hook-script lint
 ## Roadmap
 
 See [ROADMAP_2026.md](ROADMAP_2026.md) for the 90-day plan. Latest
-release: [v1.3.2](https://github.com/sattyamjjain/verdict/releases/tag/v1.3.2).
-No open tracker issues — each cycle's scope is tracked in a fresh
-issue, opened when the cycle starts and closed at release.
+release: [v2.0.1](https://github.com/sattyamjjain/verdict/releases/tag/v2.0.1)
+(additive: opt-in `duration_ms` enrichment + safety `.claude` path
+allowlist + marketplace validator v2.1.120 keys). The previous
+major, [v2.0.0](https://github.com/sattyamjjain/verdict/releases/tag/v2.0.0),
+was a breaking trim to the v4.3 plugin-only scope — see
+[`CHANGELOG.md`](CHANGELOG.md#200---2026-05-03) and the
+[v1.x → v2.0.0 migration note](#features). No open tracker issues —
+each cycle's scope is tracked in a fresh issue, opened when the
+cycle starts and closed at release.
 
 ## Contributing
 

--- a/scripts/check_readme_release_anchor.py
+++ b/scripts/check_readme_release_anchor.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Verify README.md "Latest release" anchor matches CHANGELOG's top entry.
+
+Stdlib-only. Exits 0 on match, 1 on mismatch (with a one-line
+diagnostic), 2 on missing/malformed inputs.
+
+Usage:
+    python3 scripts/check_readme_release_anchor.py
+
+Reads ``CHANGELOG.md`` for the most recent ``## [X.Y.Z] - YYYY-MM-DD``
+heading, then asserts ``README.md`` carries a matching
+``releases/tag/vX.Y.Z`` link.
+
+Design: the README's release-anchor surface is the user-visible drift
+that our v2.0.0 / v2.0.1 cycle exposed (the anchor was three releases
+behind for over a month). This check is the forcing function so the
+two files land in the same PR.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CHANGELOG_MD = REPO_ROOT / "CHANGELOG.md"
+README_MD = REPO_ROOT / "README.md"
+
+_RELEASED_HEADING = re.compile(
+    r"^##\s+\[(?P<v>\d+\.\d+\.\d+)\]\s+-\s+\d{4}-\d{2}-\d{2}",
+    re.MULTILINE,
+)
+_README_TAG_LINK = re.compile(
+    r"releases/tag/v(?P<v>\d+\.\d+\.\d+)",
+)
+
+
+def _latest_changelog_release() -> str | None:
+    if not CHANGELOG_MD.is_file():
+        print(f"Error: {CHANGELOG_MD} does not exist.", file=sys.stderr)
+        return None
+    match = _RELEASED_HEADING.search(CHANGELOG_MD.read_text(encoding="utf-8"))
+    if match is None:
+        print(
+            f"Error: {CHANGELOG_MD} has no '## [X.Y.Z] - YYYY-MM-DD' heading.",
+            file=sys.stderr,
+        )
+        return None
+    return match.group("v")
+
+
+def _readme_advertises(version: str) -> bool:
+    if not README_MD.is_file():
+        print(f"Error: {README_MD} does not exist.", file=sys.stderr)
+        return False
+    text = README_MD.read_text(encoding="utf-8")
+    for match in _README_TAG_LINK.finditer(text):
+        if match.group("v") == version:
+            return True
+    return False
+
+
+def main() -> int:
+    expected = _latest_changelog_release()
+    if expected is None:
+        return 2
+    if _readme_advertises(expected):
+        print(
+            f"README.md ✓ advertises latest CHANGELOG release v{expected}."
+        )
+        return 0
+    print(
+        f"README.md does not link to releases/tag/v{expected} — "
+        f"the 'Latest release' anchor is stale relative to CHANGELOG.md.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_marketplace.py
+++ b/scripts/validate_marketplace.py
@@ -11,15 +11,31 @@ the current working directory. Intended for CI gating and local dev.
 
 Schema source: <https://code.claude.com/docs/en/plugin-marketplaces>
 (retrieved 2026-04-18; see docs/research-log.md).
-
-Schema-evolution history (Claude Code releases that touched the
-marketplace.json / plugin.json shape):
-
-- 2.1.120 (2026-04-28) — ``claude plugin validate`` now accepts
-  ``$schema``, ``version``, ``description`` at the top level of
-  ``marketplace.json`` and ``$schema`` in ``plugin.json``.
-  <https://code.claude.com/docs/en/changelog>
 """
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Claude Code release audit log (most recent first)
+# ──────────────────────────────────────────────────────────────────────────────
+# v2.1.123 (2026-04-29) — OAuth 401 retry-loop fix when
+#   CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1. Marketplace-schema-irrelevant.
+#   No validator change required.
+# v2.1.122 (2026-04-28) — ANTHROPIC_BEDROCK_SERVICE_TIER env var; PR-URL
+#   paste in /resume; /mcp command updates. Marketplace-schema-irrelevant.
+#   No validator change required.
+# v2.1.121 (2026-04-28) — PostToolUse hooks updatedToolOutput now applies
+#   to ALL tools (was MCP-only); --dangerously-skip-permissions no longer
+#   prompts for writes to .claude/{skills,agents,commands}/; plugin prune
+#   cascade. Marketplace-schema-irrelevant; safety-dim allowlist landed
+#   in v2.0.1 score.py.
+# v2.1.120 (2026-04-28) — claude plugin validate accepts $schema, version,
+#   description at marketplace.json top level + $schema at plugin.json top
+#   level. Marketplace-schema-RELEVANT. Validator updated in v2.0.1
+#   (this file).
+# v2.1.119 (2026-04-23) — PostToolUse / PostToolUseFailure hook inputs
+#   gain duration_ms field. Marketplace-schema-irrelevant; efficiency-dim
+#   enrichment landed in v2.0.1 claude_code adapter + score.py.
+# Source: https://code.claude.com/docs/en/changelog
+# ──────────────────────────────────────────────────────────────────────────────
 from __future__ import annotations
 
 import json

--- a/skills/judge/SKILL.md
+++ b/skills/judge/SKILL.md
@@ -2,7 +2,7 @@
 name: judge
 displayName: "Verdict — Universal Quality Evaluator"
 description: "Evaluates the execution quality of any skill or agent using 7-dimension scoring with configurable rubrics"
-version: "2.0.0"
+version: "2.0.1"
 author: "Sattyam Jain"
 allowed-tools: [Read, Write, Edit, Bash]
 autoActivate:

--- a/tests/test_readme_release_anchor.py
+++ b/tests/test_readme_release_anchor.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Wraps scripts/check_readme_release_anchor.py for unittest discover.
+
+Keeps the CHANGELOG-vs-README anchor check exercisable in the local
+test suite (``python3 -m unittest discover tests/``) without
+requiring contributors to know the script lives in scripts/. Pairs
+with the CI job ``README release anchor matches CHANGELOG``.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = PROJECT_ROOT / "scripts" / "check_readme_release_anchor.py"
+
+
+class TestReadmeReleaseAnchor(unittest.TestCase):
+    def test_check_script_exits_zero(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"stderr: {result.stderr}\nstdout: {result.stdout}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate_marketplace_v2_1_120.py
+++ b/tests/test_validate_marketplace_v2_1_120.py
@@ -18,7 +18,7 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
-import validate_marketplace as vm  # noqa: E402
+import validate_marketplace as vm  # noqa: E402,F401
 
 
 def _minimal_marketplace(**overrides) -> dict:
@@ -118,6 +118,42 @@ class TestPluginEntrySchema(unittest.TestCase):
             any("version" in e for e in errors),
             msg=f"expected plugin version error in {errors}",
         )
+
+
+class TestClaudeCodeReleaseAuditLog(unittest.TestCase):
+    """Forcing function: don't silently drop the audit log comment block.
+
+    The block lists every Claude Code release that touched (or
+    explicitly did not touch) the marketplace.json / plugin.json
+    schema. A future cycle that prunes the comment would lose the
+    forward-looking sync visibility — this test surfaces the
+    deletion at PR time.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        path = PROJECT_ROOT / "scripts" / "validate_marketplace.py"
+        cls.source = path.read_text(encoding="utf-8")
+
+    def test_audit_log_lists_recent_releases(self) -> None:
+        for marker in (
+            "v2.1.119",
+            "v2.1.120",
+            "v2.1.121",
+            "v2.1.122",
+            "v2.1.123",
+        ):
+            self.assertIn(
+                marker,
+                self.source,
+                msg=(
+                    f"validate_marketplace.py audit log is missing "
+                    f"{marker}. The comment block at the top of the "
+                    f"file is the marketplace-schema sync visibility "
+                    f"surface; do not prune it without replacing the "
+                    f"oldest entries first."
+                ),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Forcing function: version stamps must agree across the manifests + CHANGELOG.
+
+PR #26 (v2.0.1 ship) cut a fresh CHANGELOG entry but did NOT bump
+``.claude-plugin/plugin.json``, ``marketplace.json``, or
+``skills/judge/SKILL.md`` frontmatter. The marketplace listing
+therefore advertised v2.0.0 even though the code was v2.0.1.
+
+This test pins:
+
+- ``plugin.json.version`` == latest ``## [X.Y.Z]`` in CHANGELOG.md
+- ``marketplace.json.plugins[*].version`` == same (when the field is present)
+- ``SKILL.md`` frontmatter ``version`` == same
+
+Adding a fresh CHANGELOG heading without bumping the other surfaces
+fails this test loudly. The test assumes the CHANGELOG follows
+Keep-a-Changelog ``## [X.Y.Z] - YYYY-MM-DD`` heading shape, which
+is the convention used since v1.0.0.
+"""
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PLUGIN_JSON = PROJECT_ROOT / ".claude-plugin" / "plugin.json"
+MARKETPLACE_JSON = PROJECT_ROOT / ".claude-plugin" / "marketplace.json"
+SKILL_MD = PROJECT_ROOT / "skills" / "judge" / "SKILL.md"
+CHANGELOG_MD = PROJECT_ROOT / "CHANGELOG.md"
+
+# Latest released version is the FIRST ``## [X.Y.Z] - ...`` heading
+# (an `[Unreleased]` heading immediately above is allowed and skipped).
+_RELEASED_HEADING = re.compile(
+    r"^##\s+\[(?P<v>\d+\.\d+\.\d+)\]\s+-\s+\d{4}-\d{2}-\d{2}",
+    re.MULTILINE,
+)
+_FRONTMATTER_VERSION = re.compile(r'^version:\s*"?(\d+\.\d+\.\d+)"?', re.MULTILINE)
+
+
+def _changelog_latest_released() -> str:
+    text = CHANGELOG_MD.read_text(encoding="utf-8")
+    match = _RELEASED_HEADING.search(text)
+    if match is None:
+        raise AssertionError(
+            "CHANGELOG.md has no ``## [X.Y.Z] - YYYY-MM-DD`` heading. "
+            "The latest released version cannot be inferred."
+        )
+    return match.group("v")
+
+
+class TestVersionConsistency(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.expected = _changelog_latest_released()
+
+    def test_plugin_json_version_matches_changelog(self) -> None:
+        manifest = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
+        self.assertEqual(
+            manifest.get("version"),
+            self.expected,
+            f".claude-plugin/plugin.json version ({manifest.get('version')!r}) "
+            f"must match the latest CHANGELOG release ({self.expected!r}).",
+        )
+
+    def test_marketplace_json_versions_match_changelog(self) -> None:
+        market = json.loads(MARKETPLACE_JSON.read_text(encoding="utf-8"))
+        plugins = market.get("plugins") or []
+        for i, plugin in enumerate(plugins):
+            if not isinstance(plugin, dict) or "version" not in plugin:
+                continue
+            self.assertEqual(
+                plugin["version"],
+                self.expected,
+                f"marketplace.json plugins[{i}].version "
+                f"({plugin['version']!r}) must match the latest "
+                f"CHANGELOG release ({self.expected!r}).",
+            )
+
+    def test_skill_md_frontmatter_version_matches_changelog(self) -> None:
+        # Read only the frontmatter (everything before the second ``---``).
+        text = SKILL_MD.read_text(encoding="utf-8")
+        if not text.startswith("---"):
+            self.fail("SKILL.md is missing a YAML frontmatter block.")
+        end = text.find("\n---", 3)
+        frontmatter = text[: end if end != -1 else len(text)]
+        match = _FRONTMATTER_VERSION.search(frontmatter)
+        self.assertIsNotNone(
+            match,
+            "SKILL.md frontmatter is missing a ``version:`` field.",
+        )
+        assert match is not None
+        self.assertEqual(
+            match.group(1),
+            self.expected,
+            f"SKILL.md frontmatter version ({match.group(1)!r}) must "
+            f"match the latest CHANGELOG release ({self.expected!r}).",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Three cosmetic-but-shippable drifts surfaced post-v2.0.1 ship. **No behaviour changes.** The v4.3 plugin-only scope contract is unchanged.

| Drift | Where | Fix |
|-------|-------|-----|
| **D1** | `.claude-plugin/plugin.json` `version: "2.0.0"` (CHANGELOG cut at v2.0.1) | Bump to `2.0.1`; new `tests/test_version_consistency.py` forcing function |
| **D2** | `skills/judge/SKILL.md` frontmatter `version: "2.0.0"` | Bump to `2.0.1`; covered by the same forcing-function test |
| **D3** | `README.md` "Latest release" anchor at `v1.3.2` (now 5 releases stale) | Refresh to `v2.0.1` with two-sentence migration callout; new `scripts/check_readme_release_anchor.py` wired into CI |

Plus an additive comment-block to `scripts/validate_marketplace.py` enumerating Claude Code v2.1.119 / v2.1.120 / v2.1.121 / v2.1.122 / v2.1.123 with marketplace-schema-relevance flags. Forcing-function grep test pins the comment block.

## Why now

PR #26 (v2.0.1 ship, merged 2026-05-04) landed three additive code rows but did NOT bump version stamps or refresh the README release anchor. The marketplace listing and any installer reading the manifest currently advertises v2.0.0 even though the code is v2.0.1.

## Test plan

- [x] `python3 -m unittest discover tests/` → **512 / 512 green** (507 → 512; +5 from new test files / cases)
- [x] `python3 scripts/benchmark_pack.py` → 7 / 7 green on the trimmed corpus
- [x] `python3 scripts/validate_marketplace.py` → marketplace.json valid
- [x] `python3 scripts/check_readme_release_anchor.py` → README advertises latest CHANGELOG release v2.0.1
- [x] `python3 -m unittest tests.test_v43_scope_contract -v` → green (no rubric files touched)
- [x] `python3 -m unittest tests.test_skill_md_conformance -v` → green (only frontmatter `version` field changed)
- [ ] CI green (tests + validators + benchmark gate + shellcheck)

## Post-merge

Force-update the existing `v2.0.1` git tag to point at the new merge commit. The tag was cut yesterday at `cf139028` where `plugin.json` still said `2.0.0`; after merge, `main` will have `plugin.json="2.0.1"` and the tag should match.

## Migration

**No action required.** All edits are cosmetic / documentary / forcing-function. No public API or scorecard shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)