### PR TITLE
chore: post-v2.0.2 hygiene — rotate release-audit comment block to v2.1.125-v2.1.129; document cross-family critic pattern (Rubber Duck) on llm_judge analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Documentation
+
+- Added a "Cross-family second-opinion pattern note" to the
+  `skills/judge/analyzers/llm_judge.py` module docstring, citing
+  GitHub Copilot CLI's Rubber Duck (cross-family critic, expanded
+  model pairings shipped 2026-05-07) as independent corroboration
+  of the pattern this analyzer already implements. Off-by-default,
+  stdlib-only, opt-in via `judge-config.json.llm_second_opinion.enabled`.
+  Mirrored as a one-paragraph subsection in `skills/judge/SKILL.md`'s
+  v1.1.0 features block. New `tests/test_llm_judge_docstring_rubber_duck_citation.py`
+  pins the citation to the GitHub Changelog primary URL (no
+  aggregators). Source:
+  <https://github.blog/changelog/2026-05-07-rubber-duck-in-github-copilot-cli-now-supports-more-models/>.
+
+### Changed
+
+- Rotated the Claude Code release audit comment block in
+  `scripts/validate_marketplace.py` to the most-recent five
+  releases (newest first): v2.1.129 / v2.1.128 / v2.1.127 / v2.1.126 /
+  v2.1.125. Earlier per-row entries (v2.1.124 through v2.1.119) were
+  pruned from the table per the ≤5-release cap; the footer paragraph
+  preserves the audit history. None of v2.1.127 / v2.1.128 / v2.1.129
+  is marketplace-schema-relevant. Extended grep test pins the rotation.
+
+### Notes
+
+- No version stamp bump; `[Unreleased]` only. The next stamped
+  release will roll up these documentation + audit-block changes
+  alongside whatever code change motivates the cut.
+
 ## [2.0.2] - 2026-05-06
 
 Patch release. Defensive-compatibility extension to the safety-

--- a/scripts/validate_marketplace.py
+++ b/scripts/validate_marketplace.py
@@ -16,6 +16,23 @@ Schema source: <https://code.claude.com/docs/en/plugin-marketplaces>
 # ──────────────────────────────────────────────────────────────────────────────
 # Claude Code release audit log (most recent five, newest first)
 # ──────────────────────────────────────────────────────────────────────────────
+# v2.1.129 (≤2026-05-08) — worktree.baseRef setting (`fresh` | `head`);
+#   default flipped back to `fresh` (was local HEAD in v2.1.128); new
+#   sandbox.bwrapPath and sandbox.socatPath managed settings (Linux/WSL).
+#   Marketplace-schema-irrelevant.
+# v2.1.128 (≤2026-05-07) — gateway /v1/models discovery on /model picker
+#   is now opt-in via CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1 (was
+#   automatic in v2.1.126); Ctrl+R history picker defaults to searching
+#   all prompts across all projects (matches pre-v2.1.124 behavior);
+#   third-party deployments no longer see spinner tips that point at
+#   first-party Anthropic surfaces; skillOverrides setting now respects
+#   different visibility options; claude_code.pull_request.count OTel
+#   metric now counts PRs/MRs created via MCP tools.
+#   Marketplace-schema-irrelevant.
+# v2.1.127 (≤2026-05-03) — bridge release between v2.1.126 and v2.1.128
+#   per claudefa.st digest; no individually documented surface change
+#   that affects verdict's transcript-shape or safety-allowlist surfaces.
+#   Marketplace-schema-irrelevant.
 # v2.1.126 (2026-05-01) — /model picker reads gateway /v1/models when
 #   ANTHROPIC_BASE_URL is set; claude project purge [path]; the
 #   --dangerously-skip-permissions allowlist now also covers .git/,
@@ -25,20 +42,12 @@ Schema source: <https://code.claude.com/docs/en/plugin-marketplaces>
 # v2.1.125 (2026-04-30/05-01) — alwaysLoad option for MCP server config;
 #   claude plugin prune for orphaned plugin deps; type-to-filter search
 #   box on /skills. Marketplace-schema-irrelevant.
-# v2.1.124 (2026-04-30) — broad update: faster MCP / plugin workflows;
-#   skill search box; richer hooks; improved terminal / fullscreen;
-#   better SDK + VSCode; stability fixes (memory leaks, resume crashes,
-#   OAuth, shell tools). Marketplace-schema-irrelevant.
-# v2.1.123 (2026-04-29) — OAuth 401 retry-loop fix when
-#   CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1. Marketplace-schema-
-#   irrelevant. No validator change required.
-# v2.1.122 (2026-04-28) — ANTHROPIC_BEDROCK_SERVICE_TIER env var; PR-URL
-#   paste in /resume; /mcp command updates. Marketplace-schema-
-#   irrelevant. No validator change required.
-# Earlier audited entries (v2.1.121 / v2.1.120 / v2.1.119) pruned per
-# the ≤5-release cap. v2.1.121 safety-allowlist + v2.1.120 marketplace
-# validator keys + v2.1.119 duration_ms enrichment all landed in v2.0.1
-# (CHANGELOG [2.0.1] - 2026-05-04).
+# Earlier audited entries (v2.1.124 / v2.1.123 / v2.1.122 / v2.1.121 /
+# v2.1.120 / v2.1.119) pruned per the ≤5-release cap. v2.1.121
+# safety-allowlist + v2.1.120 marketplace validator keys + v2.1.119
+# duration_ms enrichment all landed in v2.0.1 (CHANGELOG [2.0.1] -
+# 2026-05-04). v2.1.122–v2.1.124 were marketplace-schema-irrelevant
+# bridge / stability releases.
 # Source: https://code.claude.com/docs/en/changelog
 # ──────────────────────────────────────────────────────────────────────────────
 from __future__ import annotations

--- a/skills/judge/SKILL.md
+++ b/skills/judge/SKILL.md
@@ -372,3 +372,10 @@ help" checks.
 - `python3 scripts/benchmark_pack.py` — runs the curated corpus in
   `benchmarks/` and asserts each case satisfies its expected bounds.
   Wire into CI to catch heuristic regressions.
+
+### Opt-in cross-family second opinion
+
+(The opt-in LLM second-opinion analyzer at `analyzers/llm_judge.py`
+mirrors the cross-family critic pattern reaffirmed by GitHub Copilot
+CLI's Rubber Duck on 2026-05-07. Off by default; enable via
+`judge-config.json.llm_second_opinion.enabled`.)

--- a/skills/judge/analyzers/llm_judge.py
+++ b/skills/judge/analyzers/llm_judge.py
@@ -21,6 +21,15 @@ No ``anthropic`` pip package is imported. Callers who want to inject
 a custom client (mock in tests, hit a proxy in prod) can construct an
 ``AnthropicClient`` subclass or any object that implements
 ``messages_create(model: str, system: str, prompt: str, max_tokens: int) -> str``.
+
+Cross-family second-opinion pattern note (2026-05-09): GitHub
+Copilot CLI's Rubber Duck (cross-family critic, expanded model
+pairings shipped 2026-05-07) is the same pattern this analyzer
+implements: an opt-in second model from a different family reviews
+the first model's output. Verdict runs this off-by-default and
+stdlib-only; the critic is one signal among many, NOT a leaderboard
+verdict. Source:
+https://github.blog/changelog/2026-05-07-rubber-duck-in-github-copilot-cli-now-supports-more-models/
 """
 from __future__ import annotations
 

--- a/tests/test_llm_judge_docstring_rubber_duck_citation.py
+++ b/tests/test_llm_judge_docstring_rubber_duck_citation.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Forcing-function: pin the Rubber Duck cross-family-critic citation.
+
+`skills/judge/analyzers/llm_judge.py` carries a module-docstring note
+referencing GitHub Copilot CLI's Rubber Duck (2026-05-07) as
+independent corroboration of the cross-family critic pattern verdict
+already implements. This test pins:
+
+1. The substring "Rubber Duck" appears in the analyzer source exactly
+   once (no accidental duplication on future edits).
+2. The primary URL — github.blog/changelog/2026-05-07-rubber-duck-...
+   — appears verbatim. Aggregator URLs are NOT acceptable.
+
+Why this test exists: cross-family-critic is a recognized product
+surface at multiple vendors, not a verdict-novel concept. The
+docstring note makes that legibility explicit. A future edit that
+deletes the note (intentionally or by accident) would surface here.
+Source: <https://code.claude.com/docs/en/changelog>-style external
+anchor, recorded once.
+"""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+LLM_JUDGE_PATH = (
+    PROJECT_ROOT / "skills" / "judge" / "analyzers" / "llm_judge.py"
+)
+PRIMARY_URL_FRAGMENT = (
+    "github.blog/changelog/"
+    "2026-05-07-rubber-duck-in-github-copilot-cli-now-supports-more-models"
+)
+
+
+class TestRubberDuckCitation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.source = LLM_JUDGE_PATH.read_text(encoding="utf-8")
+
+    def test_rubber_duck_substring_present_exactly_once(self) -> None:
+        count = self.source.count("Rubber Duck")
+        self.assertEqual(
+            count,
+            1,
+            msg=(
+                f"analyzers/llm_judge.py mentions 'Rubber Duck' "
+                f"{count} time(s); expected exactly 1. The docstring "
+                f"block citing the 2026-05-07 GitHub Copilot CLI "
+                f"announcement is the single source of truth — do not "
+                f"duplicate it elsewhere in the file."
+            ),
+        )
+
+    def test_primary_url_fragment_present(self) -> None:
+        self.assertIn(
+            PRIMARY_URL_FRAGMENT,
+            self.source,
+            msg=(
+                "analyzers/llm_judge.py is missing the GitHub Changelog "
+                "primary URL fragment "
+                f"({PRIMARY_URL_FRAGMENT!r}). Aggregator URLs are NOT "
+                "acceptable; the citation must point at the GitHub "
+                "Changelog primary."
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate_marketplace_v2_1_120.py
+++ b/tests/test_validate_marketplace_v2_1_120.py
@@ -136,12 +136,15 @@ class TestClaudeCodeReleaseAuditLog(unittest.TestCase):
         cls.source = path.read_text(encoding="utf-8")
 
     def test_audit_log_lists_most_recent_five(self) -> None:
+        # Most recent five per the post-v2.0.2 hygiene rotation
+        # (chore/2026-05-09): newest first is v2.1.129; oldest in the
+        # window is v2.1.125. Anything older is footer-only.
         for marker in (
-            "v2.1.122",
-            "v2.1.123",
-            "v2.1.124",
             "v2.1.125",
             "v2.1.126",
+            "v2.1.127",
+            "v2.1.128",
+            "v2.1.129",
         ):
             self.assertIn(
                 marker,
@@ -155,12 +158,30 @@ class TestClaudeCodeReleaseAuditLog(unittest.TestCase):
                 ),
             )
 
-    def test_audit_log_pruned_oldest_three(self) -> None:
-        # v2.1.119 / v2.1.120 / v2.1.121 were rotated out in v2.0.2.
-        # The footer paragraph names them as "earlier audited entries
-        # pruned per the ≤5-release cap" — the markers themselves
-        # appear there. Anything earlier should be absent entirely.
-        for pruned in ("v2.1.118",):
+    def test_audit_log_pruned_pre_v2_1_125_per_block_entries(self) -> None:
+        # v2.1.122 / v2.1.123 / v2.1.124 were rotated out of the per-row
+        # block. Their markers may appear in the footer summary line, so
+        # this test asserts they are NOT carried as their own per-row
+        # entries (regex anchors on the leading "# v2.1.12X (" shape used
+        # by every per-row entry). The footer note is plain prose and
+        # does not match this regex.
+        for pruned in ("v2.1.122", "v2.1.123", "v2.1.124"):
+            pattern = f"# {pruned} ("
+            self.assertNotIn(
+                pattern,
+                self.source,
+                msg=(
+                    f"validate_marketplace.py audit log still carries "
+                    f"a per-row entry for {pruned}. The block must stay "
+                    f"at exactly the most recent five per-row entries; "
+                    f"older releases belong in the footer summary line."
+                ),
+            )
+
+    def test_audit_log_pruned_pre_v2_1_122(self) -> None:
+        # Anything earlier than v2.1.122 should be absent entirely
+        # (the pre-v2.0.2 cohort was already rotated out before today).
+        for pruned in ("v2.1.118", "v2.1.117"):
             self.assertNotIn(
                 pruned,
                 self.source,


### PR DESCRIPTION
## Summary

Two small documentation + audit-block hygiene rows. **No behaviour changes. No version bump. `[Unreleased]` only.** The v4.3 plugin-only scope contract is unchanged — zero rubric files / adapter files touched.

| Row | Source signal | Effect |
|-----|---------------|--------|
| **UPDATE-2** | Three new Claude Code releases since v2.0.2: v2.1.127 (bridge), v2.1.128 (gateway `/v1/models` discovery now opt-in via `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`), v2.1.129 (`worktree.baseRef`, `sandbox.bwrapPath`, `sandbox.socatPath`). [Source](https://code.claude.com/docs/en/changelog). | Rotate `validate_marketplace.py` audit comment block to most-recent 5 (newest first): v2.1.129 → v2.1.125. Prune per-row entries v2.1.124 / v2.1.123 / v2.1.122 (footer summary preserved). All three new releases are marketplace-schema-irrelevant. Extended grep test pins the rotation. |
| **UPDATE-1** | [GitHub Copilot CLI Rubber Duck (2026-05-07)](https://github.blog/changelog/2026-05-07-rubber-duck-in-github-copilot-cli-now-supports-more-models/) — cross-family critic pattern, expanded model pairings shipped 2 days ago | Add a 6-line "Cross-family second-opinion pattern note" to `analyzers/llm_judge.py` module docstring (the analyzer this verdict ships already implements this pattern, off-by-default). Mirrored as a one-paragraph subsection in `SKILL.md`'s v1.1.0 features block. New `tests/test_llm_judge_docstring_rubber_duck_citation.py` forces the GitHub Changelog primary URL and pins "Rubber Duck" as a single occurrence. |

## Test plan

- [x] `python3 -m unittest discover tests/` → **541 / 541 green** (538 → 541; +3)
- [x] `python3 scripts/benchmark_pack.py` → 7 / 7 green
- [x] `python3 scripts/validate_marketplace.py` → marketplace.json valid
- [x] `python3 scripts/check_readme_release_anchor.py` → README still advertises v2.0.2
- [x] `python3 -m unittest tests.test_v43_scope_contract -v` → green (no rubric files touched)
- [x] `python3 -m unittest tests.test_skill_md_conformance -v` → green (SKILL.md body 381 lines, ≤500)
- [x] `python3 -m unittest tests.test_version_consistency -v` → green (stamps unchanged at 2.0.2)
- [ ] CI green (tests + validators + benchmark gate + shellcheck)

## No version bump

`[Unreleased]` only. Version stamps remain at `2.0.2` (`plugin.json` / `marketplace.json` / `SKILL.md` / README anchor). The next stamped release will roll up these documentation + audit-block changes alongside whatever code change motivates the cut. No `git tag` step on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)