### PR TITLE
chore: record DELEGATE-52 outcome_corruption 8th-dimension proposal as REJECT-of-record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   release will roll up these documentation + audit-block changes
   alongside whatever code change motivates the cut.
 
+### Dispositions of record (rejected proposals)
+
+- **DELEGATE-52 / `outcome_corruption` 8th dimension (2026-05-10):
+  REJECT.** A daily-prompt row proposed adding an 8th
+  `outcome_corruption` dimension to `/judge` anchored on arXiv
+  2604.15597 ("LLMs Corrupt Your Documents When You Delegate",
+  HN front page 2026-05-09 per the prompt). **Rationale for
+  rejection:** (1) Adding a dimension regresses the "7-dimension
+  scoring" core surface explicitly listed in
+  [`CLAUDE.md` §v4.3 Scope Contract](CLAUDE.md#v43-scope-contract-2026-05-03)
+  under "do not regress." (2) The proposed signal — plan / input /
+  trace tri-way diff with "≥2 of 3 oracles agree" fail-closed — is
+  runtime trace replay against a sandbox, not heuristic transcript
+  scoring. Verdict reads transcripts post-hoc with regex; oracle
+  comparison is a different layer (Wall 2 runtime / Wall 3 outcome
+  in the prompt's own framing). (3) The proposed `skills/judge/dimensions/`
+  directory + `OutcomeCorruptionDimension` class pattern contradicts
+  the documented design noted in the 2026-05-06 prompt
+  (analyzer functions inside `score.py`, not per-dim directory).
+  arXiv ID was not independently verified at disposition time; the
+  layer-mismatch rationale stands regardless of the paper's
+  existence. Same shape as prior REJECT-of-record entries:
+  BrowseComp-Plus (2026-05-06), Managed Agents Outcomes rubric
+  beta (2026-05-09).
+
 ## [2.0.2] - 2026-05-06
 
 Patch release. Defensive-compatibility extension to the safety-


### PR DESCRIPTION
## Summary

A daily-prompt row (2026-05-10) proposed adding an 8th `outcome_corruption` dimension to `/judge` anchored on arXiv 2604.15597 (DELEGATE-52, *"LLMs Corrupt Your Documents When You Delegate"*, HN front page 2026-05-09 per the prompt).

**Disposition: REJECT-of-record.** Recording in `CHANGELOG.md` `[Unreleased] § Dispositions of record (rejected proposals)` for future-audit grep. Same shape as prior REJECTs:
- BrowseComp-Plus (2026-05-06)
- Managed Agents Outcomes rubric beta (2026-05-09)

## Rationale

1. **v4.3 contract regression.** [`CLAUDE.md` §v4.3 Scope Contract](https://github.com/sattyamjjain/verdict/blob/main/CLAUDE.md#v43-scope-contract-2026-05-03) lists "7-dimension scoring" under "Core surfaces (do not regress)." Adding an 8th dimension regresses this surface.
2. **Wrong layer for the signal.** The proposed dimension requires plan / input / trace tri-way diff with "≥2 of 3 oracles agree" fail-closed — that's runtime trace replay against a sandbox, not heuristic transcript scoring. Verdict reads transcripts post-hoc with regex; oracle comparison is a different layer (Wall 2 runtime / Wall 3 outcome in the prompt's own framing).
3. **Architectural inversion.** The proposed `skills/judge/dimensions/` directory + class-based `OutcomeCorruptionDimension` pattern contradicts the documented design noted in the 2026-05-06 prompt (verdict ships dimensions as analyzer functions inside `skills/judge/scripts/score.py`, not per-dim directory).

arXiv ID was not independently verified at disposition time; the layer-mismatch rationale stands regardless of the paper's existence.

## Test plan

- [x] `python3 -m unittest discover tests/` → **541 / 541 green** (no behaviour change)
- [x] `python3 scripts/check_readme_release_anchor.py` → still v2.0.2
- [x] `python3 -m unittest tests.test_version_consistency -v` → green (stamps unchanged)
- [x] `python3 -m unittest tests.test_v43_scope_contract -v` → green (no rubric files touched)
- [ ] CI green (tests + validators + benchmark gate + shellcheck)

## No version bump

`[Unreleased]` only. Stamps remain at `2.0.2`. No `git tag` step on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)