### PR TITLE
chore: record metis_safety + LangSmith/Cowork proposals as REJECT-of-record; verify cowork adapter unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dispositions of record (rejected proposals)
 
+- **`metis_safety` 12th rubric + Cowork-vs-LangSmith adapter
+  "schema drift" check (2026-05-18): REJECT.** Two daily-prompt
+  rows proposed (a) adding a 12th `metis_safety.yaml` rubric to
+  `skills/judge/rubrics/` anchored on "Metis paper (arXiv
+  2605.10067)" and (b) verifying the Cowork transcript adapter
+  against a "post-LangChain-Interrupt schema" (LangSmith Engine,
+  May 13). **Rationale for rejection:** (1) The rubric inventory
+  is pinned at exactly 11 by
+  [`CLAUDE.md` §v4.3 Scope Contract](CLAUDE.md#v43-scope-contract-2026-05-03)
+  and enforced by `tests/test_v43_scope_contract.py`; a 12th
+  rubric file dropped in `skills/judge/rubrics/` makes that test
+  red on PR push. (2) Verdict's rubrics are `.md` files; there is
+  no YAML parser in `score.py` (stdlib-only invariant). (3) The
+  prompt's project-shape references — `pyproject.toml`,
+  `tests/rubrics/`, "Cowork plugin index" — do not exist in this
+  repo; tells the row was templated from a different repo's
+  conventions. (4) arXiv 2605.10067 was not independently
+  verified at disposition time; the contract + shape mismatches
+  stand regardless. (5) The Cowork adapter is unrelated to
+  LangSmith — Cowork is Anthropic's collaborative Claude product,
+  LangSmith is LangChain's tracing product; nothing in a
+  LangChain Interrupt release affects Cowork transcripts.
+  **Cowork sanity sweep performed anyway as a no-op check:**
+  `tests.test_adapters.TestCoworkAdapter` + `tests.test_adapter_fixtures.TestCoworkFixture`
+  green; `skills/judge/adapters/cowork.py` is a 19-line
+  delegation wrapper over `claude_code.extract_lines` (Cowork
+  emits the same JSONL shape as Claude Code), last touched in
+  commit `70ed8eb` (Phase 2); fixture `tests/fixtures/cowork.jsonl`
+  unchanged. **No drift detected; no patch required.** Same
+  shape as prior REJECT-of-record entries: BrowseComp-Plus
+  (2026-05-06), Managed Agents Outcomes rubric beta (2026-05-09),
+  DELEGATE-52 (2026-05-10).
+
 - **DELEGATE-52 / `outcome_corruption` 8th dimension (2026-05-10):
   REJECT.** A daily-prompt row proposed adding an 8th
   `outcome_corruption` dimension to `/judge` anchored on arXiv


### PR DESCRIPTION
## Summary

Two daily-prompt rows (2026-05-18) proposed:
1. Adding a 12th `metis_safety.yaml` rubric anchored on arXiv 2605.10067 (Metis paper)
2. Verifying the Cowork adapter against a "post-LangChain-Interrupt schema" (LangSmith Engine, May 13)

**Disposition: REJECT-of-record for both.** Recording in `CHANGELOG.md` `[Unreleased] § Dispositions of record` for future-audit grep. Same shape as prior REJECTs:
- BrowseComp-Plus (2026-05-06)
- Managed Agents Outcomes rubric beta (2026-05-09)
- DELEGATE-52 (2026-05-10)

## Rationale

### Suggestion 1 (`metis_safety` 12th rubric)

1. **v4.3 contract violation.** [`CLAUDE.md` §v4.3 Scope Contract](https://github.com/sattyamjjain/verdict/blob/main/CLAUDE.md#v43-scope-contract-2026-05-03) pins the rubric inventory at exactly **11**. `tests/test_v43_scope_contract.py` enforces this — a 12th rubric file in `skills/judge/rubrics/` makes CI red on PR push.
2. **Wrong file format.** Verdict rubrics are `.md`. No YAML parser in `score.py` (stdlib-only).
3. **Wrong repo shape.** Prompt references `pyproject.toml` (none — versions live in `.claude-plugin/plugin.json` + `marketplace.json` + `SKILL.md`), `tests/rubrics/` (none — flat layout), "Cowork plugin index" (none — single marketplace.json). Tells the prompt was templated from a different repo's conventions.
4. **Unverifiable citation.** arXiv 2605.10067 was not independently verified at disposition time; contract + shape mismatches stand regardless.

### Suggestion 2 (LangSmith / Cowork schema check)

1. **Wrong product confusion.** Cowork is Anthropic's collaborative Claude product; LangSmith is LangChain's tracing product. Cowork transcripts are unrelated to any LangChain Interrupt release.
2. **Cowork sanity sweep performed anyway as a no-op check** — no drift, no patch:
   - `tests.test_adapters.TestCoworkAdapter` → green
   - `tests.test_adapter_fixtures.TestCoworkFixture` → green
   - `skills/judge/adapters/cowork.py` is a 19-line delegation wrapper over `claude_code.extract_lines`; last touched in commit `70ed8eb` (Phase 2)
   - `tests/fixtures/cowork.jsonl` unchanged

## Test plan

- [x] `python3 -m unittest discover tests/` → **541 / 541 green** (no behaviour change)
- [x] `python3 -m unittest tests.test_v43_scope_contract -v` → green (rubric inventory unchanged)
- [x] `python3 -m unittest tests.test_skill_md_conformance -v` → green
- [x] `python3 -m unittest tests.test_version_consistency -v` → green (stamps unchanged at 2.0.2)
- [x] `python3 scripts/check_readme_release_anchor.py` → still v2.0.2
- [x] Cowork adapter regression suite → green; no drift
- [ ] CI green (tests + validators + benchmark gate + shellcheck)

## No version bump

`[Unreleased]` only. Stamps remain at `2.0.2`. No `git tag` step on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)