### PR TITLE
docs: sync README architecture tree with actual scripts/ inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- Synced README architecture tree with the actual `scripts/`
+  inventory: added the missing `check_readme_release_anchor.py`
+  entry (shipped in PR #27 on 2026-05-05 as the CHANGELOG ↔ README
+  anchor forcing function but never reflected in the tree).
+  Surfaced by the 2026-05-20 README-sync audit. No behaviour
+  change; tree was 4-of-5; now reads 5-of-5.
+
 - Added a "Cross-family second-opinion pattern note" to the
   `skills/judge/analyzers/llm_judge.py` module docstring, citing
   GitHub Copilot CLI's Rubber Duck (cross-family critic, expanded

--- a/README.md
+++ b/README.md
@@ -212,10 +212,11 @@ hooks/
   common.sh, judge-on-stop.sh, judge-on-subagent-stop.sh, judge-on-stop-failure.sh
 commands/                  # /judge, /scorecard, /benchmark, /judge-config, /against, /compare
 scripts/
-  validate_marketplace.py  # Schema validator
-  install_rubric.py        # Fetch + validate community rubrics
-  benchmark_pack.py        # Regression gate for CI
-  sandbox_caps_check.py    # CLAUDE_SANDBOX_CAPS declaration check (CI)
+  validate_marketplace.py        # Schema validator
+  install_rubric.py              # Fetch + validate community rubrics
+  benchmark_pack.py              # Regression gate for CI
+  sandbox_caps_check.py          # CLAUDE_SANDBOX_CAPS declaration check (CI)
+  check_readme_release_anchor.py # CHANGELOG ↔ README anchor forcing-function (CI)
 benchmarks/
   manifest.json + corpus/  # Regression-gate fixtures (NOT a public eval bench — see benchmarks/README.md)
 .github/workflows/


### PR DESCRIPTION
## Summary

Surfaced by the 2026-05-20 README-sync audit: the architecture tree in `README.md` listed only 4 of 5 actual `scripts/` files. The missing entry is `check_readme_release_anchor.py`, which shipped in PR #27 (2026-05-05) as the CHANGELOG ↔ README anchor forcing function but was never reflected in the tree.

| Surface | Before | After |
|---|---|---|
| README architecture tree `scripts/` block | 4 files | 5 files (matches actual) |
| Actual `scripts/` directory | 5 files | 5 files (unchanged) |

## Test plan

- [x] `python3 -m unittest discover tests/` → **541 / 541 green**
- [x] `python3 scripts/check_readme_release_anchor.py` → still v2.0.2
- [x] `python3 -m unittest tests.test_version_consistency -v` → green
- [x] Manual: `ls scripts/*.py` matches README block line-for-line
- [ ] CI green

## No version bump

`[Unreleased]` only. Stamps unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)