### PR TITLE
feat(bench): add ABA-anchored task-hygiene lint to benchmark pack (v2.0.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "verdict",
       "source": "./",
       "description": "Auto-evaluates skill and agent execution quality with 7-dimension scoring, configurable rubrics, and dual-mode operation.",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "category": "quality-assurance",
       "tags": ["judge", "evaluation", "quality", "scoring", "LLM-as-judge"],
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verdict",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "displayName": "Verdict — Universal Skill & Agent Quality Judge",
   "description": "The first universal judge for Claude Code & Cowork. Auto-evaluates skill and agent execution quality with 7-dimension scoring, configurable rubrics, and dual-mode operation (auto hooks + manual /judge command).",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   BrowseComp-Plus (2026-05-06), Managed Agents Outcomes rubric
   beta (2026-05-09).
 
+## [2.0.3] - 2026-05-28
+
+Patch release. Adds an ABA-anchored task-hygiene lint to the
+benchmark pack so a suspect regression-gate corpus can be caught
+*before* its scores are consumed by CI.
+
+### Added
+
+- `scripts/bench_lint.py` — offline, stdlib-only hygiene lint for
+  the regression-gate manifest. Implements four rules adapted from
+  the Auto Benchmark Audit framework (Wang et al. 2026,
+  arXiv:2605.26079, "Automated Benchmark Auditing for AI Agents
+  and Large Language Models", v1 2026-05-25):
+
+    * **VBL001 SpecificationGap** — missing `name`/`skill`, or no
+      `expected_*` bound declared (case asserts nothing).
+    * **VBL002 EnvironmentCoupling** — absolute transcript path,
+      path escapes the manifest dir via `..`, transcript file
+      missing on disk, or declared `adapter` doesn't match the
+      file suffix.
+    * **VBL003 BrittleGrading** — single-point composite/grade/dim
+      bounds (`min == max`), or composite range narrower than 0.5.
+    * **VBL004 MissingGroundTruth** — transcript is 0-bytes or
+      contains zero non-blank lines.
+
+  Aggregate `bench_hygiene_score = 1 - flagged_cases / total_cases`.
+  Emits text (default), JSON (`--json`), or SARIF v2.1.0
+  (`--sarif PATH`). Exits 0 above threshold (default 0.85), 1 below,
+  2 on IO/arg failure. No LLM call — the offline heuristic is the
+  moat.
+
+- Ship-gate wire-up in `scripts/benchmark_pack.py`: new `--lint`
+  flag runs the hygiene pass *before* the regression suite and
+  aborts non-zero if `bench_hygiene_score` is below
+  `--hygiene-threshold` (default 0.85). `--sarif PATH` implies
+  `--lint` and writes the SARIF document. CI now surfaces "this
+  benchmark may not be trustworthy" instead of greenwashing a
+  suspect corpus. Legacy positional manifest argument preserved.
+
+### Tests
+
+- `tests/test_bench_lint.py` (21 tests): the shipped
+  `benchmarks/manifest.json` scores 1.0 and exits 0; each of the
+  four rule classes fires on an injected bad case; SARIF v2.1.0
+  envelope and rule inventory pinned; exit-code matrix verified
+  (0 above / 1 below / 2 IO-or-arg); `benchmark_pack --lint`
+  aborts before the regression suite when the corpus is dirty
+  and surfaces the VBL ruleId in stderr.
+
+### Notes
+
+- Verdict's benchmark pack scores *transcripts* against expected
+  score bounds, not *tasks* against ground-truth outputs. The four
+  ABA classes therefore apply by analogy, not literally; the lint
+  output and README both state this adaptation explicitly so
+  nobody reads it as a 1:1 ABA implementation. The 25.7%-of-tasks
+  flaw rate ABA reports across 168 benchmarks is the motivation
+  for catching the same shape of issue before scores ship.
+
+- O17 — `bench_lint.py` adapts ABA to a transcript-regression
+  manifest. If Verdict ever grows a true task benchmark (prompt +
+  expected output + grader), the four rules will need a literal
+  pass: spec gaps against the prompt text, env coupling against
+  the grader's external calls, brittle grading against
+  exact-match-only graders, missing ground truth against empty
+  expected outputs.
+
 ## [2.0.2] - 2026-05-06
 
 Patch release. Defensive-compatibility extension to the safety-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-<!-- AUTO-MANAGED: project-description -->
+<!-- MANUAL: project-description -->
 ## Overview
 
 **Verdict** is a Claude Code plugin that auto-evaluates skill and agent execution quality. It provides 7-dimension scoring (correctness, completeness, adherence, actionability, efficiency, safety, consistency), configurable rubrics, persistent scorecards, and dual-mode operation (auto via hooks + manual via `/judge` command). Works on both Claude Code and Claude Cowork.
@@ -11,7 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - License: MIT
 - Platforms: `claude-code`, `claude-cowork`
 
-<!-- END AUTO-MANAGED -->
+<!-- END MANUAL -->
 
 <!-- MANUAL: v43-scope-contract -->
 ## v4.3 Scope Contract (2026-05-03)
@@ -35,13 +35,34 @@ Verdict is a **Claude Code / Cowork plugin only.** Per the 2026-05-03 v4.3 scope
 <!-- AUTO-MANAGED: build-commands -->
 ## Build & Development Commands
 
-This project has no build step or package manager. Python scripts use stdlib only (Python 3.9+).
+This project has no build step or package manager. Python scripts use stdlib only (Python 3.9+); the optional LLM second-opinion analyzer uses `urllib.request` rather than pulling in the `anthropic` SDK.
 
+**Core scoring & reporting**
 - **Run scoring engine**: `python3 skills/judge/scripts/score.py --skill SKILL --transcript PATH --rubric-dir skills/judge/rubrics --scores-dir skills/judge/scores --config judge-config.json`
 - **Run report viewer**: `python3 skills/judge/scripts/report.py --scores-dir skills/judge/scores [--skill NAME] [--last N] [--format text|json]`
 - **Run benchmark comparator**: `python3 skills/judge/scripts/benchmark.py --skill NAME --scores-dir skills/judge/scores --references-dir skills/judge/references`
-- **Run tests**: `python3 -m unittest discover tests/ -v`
-- **No linter**: No linting or formatting tools are configured.
+
+**Newer subcommands**
+- **Compare two runs**: `python3 skills/judge/scripts/compare.py --a SCORE_A.json --b SCORE_B.json` (powers `/compare`)
+- **Judge against a reference**: `python3 skills/judge/scripts/against.py --skill SKILL --reference REF.json` (powers `/against`)
+- **Explain a scorecard**: `python3 skills/judge/scripts/explain.py --score SCORE.json` — human-readable dimension breakdown
+- **Estimate LLM-judge cost**: `python3 skills/judge/scripts/cost_estimator.py --transcript PATH --config judge-config.json`
+- **Interactive studio**: `python3 skills/judge/scripts/studio.py` — TUI for browsing scores
+- **Continuous watch**: `python3 skills/judge/scripts/watch.py --scores-dir skills/judge/scores`
+- **Lint hook scripts**: `python3 skills/judge/scripts/hook_lint.py hooks/*.sh`
+
+**Validation & repo tooling (top-level `scripts/`)**
+- **Validate marketplace.json**: `python3 scripts/validate_marketplace.py`
+- **Install a third-party rubric**: `python3 scripts/install_rubric.py --source PATH_OR_URL`
+- **Run benchmark pack**: `python3 scripts/benchmark_pack.py`
+- **Sandbox caps check**: `python3 scripts/sandbox_caps_check.py`
+- **README release-anchor check**: `python3 scripts/check_readme_release_anchor.py`
+
+**Tests**
+- **Run all tests**: `python3 -m unittest discover tests/ -v` (29 test files; pins v4.3 scope contract, schema, adapters, hooks, LLM-judge budget, marketplace shape, version consistency, etc.)
+- **Single test**: `python3 -m unittest tests.test_v43_scope_contract -v`
+
+**Linting**: No linter is configured for the codebase. `hook_lint.py` is project-specific shell-hook safety lint, not a general linter.
 
 <!-- END AUTO-MANAGED -->
 
@@ -49,62 +70,92 @@ This project has no build step or package manager. Python scripts use stdlib onl
 ## Architecture
 
 ```
-Verdict/
+Verdict/  (v2.0.2)
 ├── .claude-plugin/
-│   ├── plugin.json              # Plugin manifest (name, version, components)
+│   ├── plugin.json              # Plugin manifest (skills, agents, commands, hooks)
 │   └── marketplace.json         # Marketplace listing metadata
 ├── skills/judge/
-│   ├── SKILL.md                 # Core skill definition (7-dimension scoring system)
-│   ├── scripts/
-│   │   ├── score.py             # Scoring engine — heuristic transcript analysis
+│   ├── SKILL.md                 # Core skill definition (7-dimension scoring)
+│   ├── scripts/                 # All Python entry points (stdlib only)
+│   │   ├── score.py             # Scoring engine — heuristic + optional LLM second opinion
 │   │   ├── report.py            # Score reporter — Unicode scorecards & trends
-│   │   ├── benchmark.py         # Benchmark comparator — delta analysis vs standards
-│   │   └── detect-skill.sh      # Skill name detection from transcripts
-│   ├── rubrics/
-│   │   ├── default.md           # Universal fallback rubric
-│   │   ├── code-review.md       # Code review domain rubric
-│   │   ├── frontend-design.md   # Frontend design domain rubric
-│   │   ├── documentation.md     # Documentation domain rubric
-│   │   ├── testing.md           # Testing domain rubric
-│   │   ├── security.md          # Security domain rubric
-│   │   ├── content-writing.md   # Content writing domain rubric
-│   │   ├── data-analysis.md     # Data analysis domain rubric
-│   │   ├── research.md          # Research & exploration domain rubric
-│   │   ├── devops.md            # DevOps & infrastructure domain rubric
-│   │   └── custom-template.md   # Template for creating new rubrics
-│   ├── scores/                  # Persisted score JSON files (gitignored by default)
+│   │   ├── benchmark.py         # Benchmark comparator — delta vs standards
+│   │   ├── against.py           # /against — judge a run against a reference
+│   │   ├── compare.py           # /compare — diff two scorecards
+│   │   ├── explain.py           # /judge-config explain — verbose breakdown
+│   │   ├── cost_estimator.py    # Pre-flight LLM-judge token/cost estimate
+│   │   ├── studio.py            # Interactive TUI for score browsing
+│   │   ├── watch.py             # Long-running watcher over scores/
+│   │   ├── hook_lint.py         # Lint hook shell scripts for safety
+│   │   └── detect-skill.sh      # Skill-name detection from transcripts
+│   ├── analyzers/
+│   │   └── llm_judge.py         # Opt-in LLM second-opinion analyzer (urllib only)
+│   ├── adapters/                # Cross-platform transcript readers (the 4 in-scope)
+│   │   ├── claude_code.py
+│   │   ├── cowork.py
+│   │   ├── codex.py
+│   │   └── openai_compatible.py
+│   ├── exporters/               # Scorecard exporters
+│   ├── integrations/            # External integration shims
+│   ├── rubrics/                 # 11 in-scope rubrics + custom-template + sidecar weights
+│   │   ├── default.md           # Universal fallback
+│   │   ├── code-review.md, security.md, security.weights.json
+│   │   ├── devops.md, data-analysis.md, frontend-design.md
+│   │   ├── testing.md, documentation.md, content-writing.md
+│   │   ├── research.md
+│   │   └── custom-template.md
+│   ├── scores/                  # Persisted score JSON (gitignored)
 │   └── references/
 │       ├── scoring-methodology.md
 │       └── benchmark-standards.md
-├── tests/
-│   └── test_score.py            # Unit tests for scoring engine
+├── schemas/
+│   └── scorecard.v1.schema.json # JSON Schema for scorecard documents
 ├── agents/
-│   └── judge-agent.md           # Read-only evaluator agent definition
+│   └── judge-agent.md           # Read-only evaluator agent
 ├── hooks/
-│   ├── hooks.json               # Hook definitions (Stop, SubagentStop events)
-│   ├── common.sh                # Shared shell utilities (skill detection, config, deps)
-│   ├── judge-on-stop.sh         # Auto-judge hook for Stop events
-│   └── judge-on-subagent-stop.sh
-├── commands/
-│   ├── judge.md                 # /judge slash command
-│   ├── scorecard.md             # /scorecard slash command
-│   ├── benchmark.md             # /benchmark slash command
-│   └── judge-config.md          # /judge-config slash command
-├── judge-config.json            # Root configuration (auto_judge, scoring weights)
+│   ├── hooks.json               # Stop, SubagentStop, StopFailure event bindings
+│   ├── common.sh                # Shared shell utilities
+│   ├── judge-on-stop.sh
+│   ├── judge-on-subagent-stop.sh
+│   └── judge-on-stop-failure.sh # Auto-judge on StopFailure
+├── commands/                    # 6 slash commands
+│   ├── judge.md, scorecard.md, benchmark.md, judge-config.md
+│   ├── against.md               # /against
+│   └── compare.md               # /compare
+├── scripts/                     # Repo tooling (validation, install, sandbox caps)
+│   ├── validate_marketplace.py
+│   ├── install_rubric.py
+│   ├── benchmark_pack.py
+│   ├── sandbox_caps_check.py
+│   └── check_readme_release_anchor.py
+├── benchmarks/                  # Reference benchmark corpus
+│   ├── corpus/
+│   ├── manifest.json
+│   └── README.md
+├── routines/
+│   └── weekly-team-digest.md
+├── releases/                    # Release notes per version
+│   └── v1.4.2.md
+├── docs/                        # Project docs (followups, metrics, research-log, schema-registry)
+│   ├── cli/, launch/
+│   └── followups.md, metrics.md, research-log.md, schema-registry.md
+├── tests/                       # 29 test files (cli/, fixtures/, schema validators)
+├── judge-config.json            # Root config: auto_judge, manual_judge, scoring, tokenizer_baselines, llm_second_opinion
 ├── README.md
 └── CHANGELOG.md
 ```
 
 ### Data Flow
 
-1. **Auto mode**: Skill executes → `Stop` hook fires → `judge-on-stop.sh` reads transcript → detects skill name → checks config → runs `score.py` → persists JSON scorecard to `scores/`
-2. **Manual mode**: User runs `/judge` → Claude reads transcript from conversation context → applies rubric → renders scorecard → persists JSON
-3. **Reporting**: `/scorecard` reads from `scores/` directory → renders Unicode table with trends
-4. **Benchmarking**: `/benchmark` reads scores + `benchmark-standards.md` → computes deltas → renders comparison report
+1. **Auto mode**: Skill executes → `Stop` / `SubagentStop` / `StopFailure` hook fires → `judge-on-*.sh` reads transcript via `common.sh` → `detect-skill.sh` resolves skill name → `score.py` runs heuristic pass → if `llm_second_opinion.enabled`, `analyzers/llm_judge.py` adds per-dimension LLM scores → JSON scorecard persisted to `scores/` and validated against `schemas/scorecard.v1.schema.json`.
+2. **Manual mode**: User runs `/judge` → Claude reads transcript from conversation context → applies rubric → renders scorecard → persists JSON.
+3. **Cross-platform read**: `adapters/{claude_code,cowork,codex,openai_compatible}.py` normalize each platform's transcript shape into the same line stream `score.py` consumes.
+4. **Reporting**: `/scorecard` reads `scores/` → `report.py` renders Unicode table with trends. `/compare` runs `compare.py` over two scorecards; `/against` runs `against.py` vs a reference; `/judge-config explain` runs `explain.py`.
+5. **Benchmarking**: `/benchmark` reads scores + `benchmark-standards.md` → `benchmark.py` computes deltas. `scripts/benchmark_pack.py` runs the full reference corpus in `benchmarks/`.
 
 <!-- END AUTO-MANAGED -->
 
-<!-- AUTO-MANAGED: conventions -->
+<!-- MANUAL: conventions -->
 ## Code Conventions
 
 ### Python (scripts/)
@@ -132,19 +183,24 @@ Verdict/
 - Structured sections with `##` headings
 - Tables for dimension/weight/criteria specifications
 
-<!-- END AUTO-MANAGED -->
+<!-- END MANUAL -->
 
 <!-- AUTO-MANAGED: patterns -->
 ## Detected Patterns
 
-- **Heuristic scoring**: `score.py` uses regex pattern matching against transcripts rather than LLM evaluation. Patterns detect errors, incompleteness, safety issues, hallucinations, and tool call density.
+- **Heuristic scoring core, optional LLM second opinion**: `score.py` is regex/heuristic-first against transcripts. `analyzers/llm_judge.py` is opt-in (requires `judge-config.json.llm_second_opinion.enabled = true` *and* `ANTHROPIC_API_KEY`), uses `urllib.request` so no SDK dependency, and merges per-dimension `llm_score` / `llm_justification` into the scorecard. The `task-budgets-2026-03-13` beta header caps spend.
+- **Adapter pattern for cross-platform transcripts**: `adapters/{claude_code,cowork,codex,openai_compatible}.py` each normalize their platform's transcript into the same JSONL line stream `score.py` consumes — Claude Code is the reference format.
+- **Schema-validated scorecards**: All persisted scores conform to `schemas/scorecard.v1.schema.json`. Evolution rules live in `DEEP_ANALYSIS.md §Schema stability contract` (per the schema's own description).
 - **Auto-deductions and bonuses**: Red flags (hallucinations, placeholders, destructive commands) deduct up to 2.0 from composite; bonuses (edge cases, trade-off analysis) add up to 1.0. Applied after weighted composite.
-- **Context-aware safety**: Safety regex excludes discussion context (review comments, comparisons) to avoid false positives on transcripts that discuss credentials without defining them.
+- **Context-aware safety**: Safety regex excludes discussion context (review comments, comparisons) to avoid false positives on transcripts that merely discuss credentials without defining them.
+- **Per-rubric weight sidecars**: `<rubric>.weights.json` (e.g. `security.weights.json`) overrides default dimension weights without forking the rubric markdown.
+- **Auto Memory aware**: `adapters/claude_code.py` accepts either a single transcript file *or* a directory containing the `~/.claude/history/*.jsonl` shards plus the memory preamble Claude Code injects (Opus 4.7, 2026-04-17+).
 - **Graceful degradation**: All scripts handle missing files, bad JSON, and empty inputs by falling back to defaults rather than crashing. Hooks exit 0 on non-critical failures.
 - **Rubric resolution chain**: Exact match → category prefix match → `default.md` fallback.
-- **Consistent scorecard structure**: All three scripts (score, report, benchmark) produce Unicode box-drawing output with the same visual style.
-- **Config-driven behavior**: `judge-config.json` controls which skills are auto-judged, scoring weights, thresholds, and output preferences. All scripts accept config as optional parameter with sensible defaults.
+- **Consistent scorecard structure**: `score.py`, `report.py`, `benchmark.py`, `compare.py`, `against.py`, `explain.py` all share Unicode box-drawing output style.
+- **Config-driven behavior**: `judge-config.json` keys — `auto_judge`, `manual_judge`, `scoring`, `tokenizer_baselines`, `llm_second_opinion` — control which skills are auto-judged, scoring weights, thresholds, LLM-opinion gating, and output preferences.
 - **History-aware scoring**: Consistency dimension and trend indicators use historical score files for comparison.
+- **Hook safety lint**: `hook_lint.py` is project-specific lint for shell hooks (separate from general linting, which is not configured).
 - **Dependency checking**: Hook scripts verify `jq`, `bc`, and `python3` are available before executing, with install hints on failure.
 
 <!-- END AUTO-MANAGED -->
@@ -152,19 +208,26 @@ Verdict/
 <!-- AUTO-MANAGED: git-insights -->
 ## Git Insights
 
-- Main branch: `main`
-- Single-contributor project (Sattyam Jain)
+- **Main branch**: `main`. Default branch for PRs.
+- **Single-contributor** project (Sattyam Jain), but workflow mirrors a team: every change lands via a feature/chore branch + PR (`chore/<date>-<topic>`, `feature/<short-desc>`, `fix/<short-desc>`).
+- **v2.0.0 trim shipped**: The `v4.3 Scope Contract` originally described the 16 out-of-scope rubrics as still present in v1.4.2. Current `HEAD` is **v2.0.2** and the trim has happened — only the 11 in-scope rubrics remain under `skills/judge/rubrics/`.
+- **Recent work pattern** — disposition discipline: most recent merges are "REJECT-of-record" chores that document *why* a proposed change (held_out_consistency test-gaming heuristic, metis_safety, DELEGATE-52 outcome_corruption 8th dimension) was rejected, so the choice is auditable. See PRs #30–#33.
+- **Sync chore**: PR #32 synced the README architecture tree with the actual `scripts/` inventory (added `check_readme_release_anchor.py`). That same drift class is what the AUTO-MANAGED Architecture block above is now defending against in `CLAUDE.md`.
 
 <!-- END AUTO-MANAGED -->
 
 <!-- AUTO-MANAGED: best-practices -->
 ## Best Practices
 
-- When modifying Python scripts, maintain stdlib-only constraint — do not add third-party dependencies.
-- When adding new rubrics, copy `custom-template.md` and follow the existing dimension criteria table format.
-- Score JSON files in `scores/` use the naming pattern `{skill}_{timestamp}.json`.
-- Hook scripts must not block user workflow on non-critical failures (exit 0, not exit 1).
-- All dimension weights in `judge-config.json` must sum to 1.0.
+- **Keep the stdlib-only constraint** when modifying Python scripts, including the LLM-judge analyzer — use `urllib.request`, not `requests` or `anthropic`. No third-party packages.
+- **Honor the v4.3 scope contract** when adding rubrics or adapters. Anything outside the 11 in-scope rubrics or 4 in-scope adapters needs a runbook spec change first; `tests/test_v43_scope_contract.py` will fail you otherwise.
+- **New rubrics**: copy `custom-template.md` and follow the existing dimension criteria table format. If the rubric needs non-default weights, add a `<name>.weights.json` sidecar instead of editing scoring defaults.
+- **Score JSON files** in `scores/` use the naming pattern `{skill}_{timestamp}.json` and must validate against `schemas/scorecard.v1.schema.json`.
+- **Hook scripts must not block user workflow** on non-critical failures (exit 0, not exit 1). Reserve exit 2 for true threshold-breach blocks. Run `hook_lint.py` over them before committing.
+- **All dimension weights** in `judge-config.json` and any `<rubric>.weights.json` sidecar must sum to 1.0.
+- **LLM second opinion is opt-in and budgeted**: keep `llm_second_opinion.enabled = false` by default; require the `task-budgets-2026-03-13` beta header so spend is hard-capped server-side.
+- **When changing the scorecard shape**, bump the schema version under `schemas/` and update the stability contract — never silently mutate `scorecard.v1.schema.json`.
+- **Disposition discipline**: record REJECT-of-record outcomes as their own chore PR (see PRs #30–#33) so the decision is auditable later.
 
 <!-- END AUTO-MANAGED -->
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ workaround (GH #39400), see [INSTALL-COWORK.md](INSTALL-COWORK.md).
 - **Benchmark regression gate.** Curated transcript corpus plus
   `scripts/benchmark_pack.py` asserts no heuristic drift across
   releases. Wired into CI.
+- **Benchmark hygiene lint (ABA-anchored).** `scripts/bench_lint.py`
+  audits the regression-gate manifest itself for the four issue
+  classes described in [arXiv:2605.26079](https://arxiv.org/abs/2605.26079)
+  (Wang et al. 2026, *Automated Benchmark Auditing for AI Agents
+  and Large Language Models*). Surfaces a `bench_hygiene_score`,
+  text/JSON/SARIF output, and a `--lint` pre-flight gate on the
+  pack so a suspect corpus is caught before its scores ship. See
+  [§Benchmark hygiene lint](#benchmark-hygiene-lint-aba-anchored)
+  below.
 - **Stdlib only.** Python 3.9+, no third-party packages, installs
   instantly with zero supply-chain risk.
 
@@ -214,7 +223,8 @@ commands/                  # /judge, /scorecard, /benchmark, /judge-config, /aga
 scripts/
   validate_marketplace.py        # Schema validator
   install_rubric.py              # Fetch + validate community rubrics
-  benchmark_pack.py              # Regression gate for CI
+  benchmark_pack.py              # Regression gate for CI (now with --lint pre-flight)
+  bench_lint.py                  # ABA-anchored task-hygiene lint (arXiv:2605.26079)
   sandbox_caps_check.py          # CLAUDE_SANDBOX_CAPS declaration check (CI)
   check_readme_release_anchor.py # CHANGELOG ↔ README anchor forcing-function (CI)
 benchmarks/
@@ -274,17 +284,79 @@ or add new ones — the `default` key catches unknown models.
 python3 -m unittest discover tests/ -v        # full suite
 python3 scripts/validate_marketplace.py       # schema check
 python3 scripts/benchmark_pack.py             # regression gate
+python3 scripts/benchmark_pack.py --lint      # regression + ABA hygiene pre-flight
+python3 scripts/bench_lint.py                 # ABA hygiene lint alone
 shellcheck hooks/*.sh                         # hook-script lint
 ```
+
+## Benchmark hygiene lint (ABA-anchored)
+
+`scripts/bench_lint.py` audits the regression-gate manifest itself
+before any score is consumed. It adapts the four issue classes from
+[arXiv:2605.26079](https://arxiv.org/abs/2605.26079) (Wang et al.
+2026, *Automated Benchmark Auditing for AI Agents and Large
+Language Models*, v1 2026-05-25) to Verdict's transcript-regression
+shape. ABA found that **25.7% of tasks across 168 benchmarks**
+contained one of these issues, and that removing them moved model
+scores by ~9.6–9.9% — i.e., suspect bench plumbing changes the
+verdict. The lint catches the same shape of issue in our own pack
+*before* CI greenwashes a broken corpus.
+
+| Rule | Class | Triggers on |
+|------|-------|-------------|
+| **VBL001** | SpecificationGap | missing `name`/`skill`, or no `expected_*` bound declared (case asserts nothing) |
+| **VBL002** | EnvironmentCoupling | absolute transcript path, escapes manifest dir via `..`, transcript missing, or `adapter` ↔ file-suffix mismatch |
+| **VBL003** | BrittleGrading | single-point composite/grade/dim bounds (`min == max`), or composite range narrower than 0.5 |
+| **VBL004** | MissingGroundTruth | transcript is 0-bytes or contains only blank lines |
+
+```shell
+# Standalone (text by default)
+python3 scripts/bench_lint.py
+
+# JSON for piping into other tools
+python3 scripts/bench_lint.py --json | jq '.bench_hygiene_score'
+
+# SARIF v2.1.0 for CI surfacing (GitHub code-scanning, etc.)
+python3 scripts/bench_lint.py --sarif bench_lint.sarif --quiet
+
+# Custom threshold (default 0.85)
+python3 scripts/bench_lint.py --threshold 0.95
+
+# Wired into the regression gate as a pre-flight (aborts before any
+# score is consumed if the corpus is suspect)
+python3 scripts/benchmark_pack.py --lint --sarif bench_lint.sarif
+```
+
+Aggregate `bench_hygiene_score = 1 - flagged_cases / total_cases`.
+Exit codes: **0** above threshold, **1** below, **2** on IO / arg
+failure. Offline-only, stdlib-only — no LLM call (the heuristic is
+the moat; defaulting to LLM judging would push the trust boundary
+into a token-billed black box, which is exactly what we lint
+against).
+
+**Scope honesty.** Verdict's "benchmark pack" scores transcripts
+against expected score bounds, not tasks against ground-truth
+outputs (`benchmarks/manifest.json` is explicitly *not* a public
+eval bench — see `benchmarks/README.md`). The four ABA classes
+therefore apply *by analogy*, mapped to the regression-gate shape;
+the rule descriptions above and the lint's own help text make this
+adaptation explicit. If Verdict ever grows a true task benchmark,
+the rules will need a literal pass — tracked as **O17** in
+`CHANGELOG.md`.
 
 ## Roadmap
 
 See [ROADMAP_2026.md](ROADMAP_2026.md) for the 90-day plan. Latest
-release: [v2.0.2](https://github.com/sattyamjjain/verdict/releases/tag/v2.0.2)
+release: [v2.0.3](https://github.com/sattyamjjain/verdict/releases/tag/v2.0.3)
+(ABA-anchored benchmark hygiene lint + ship-gate wire-up — flags
+spec gaps, env coupling, brittle grading, and missing ground truth
+in the regression-gate manifest *before* its scores ship; SARIF
+output for CI surfacing).
+Previous releases:
+[v2.0.2](https://github.com/sattyamjjain/verdict/releases/tag/v2.0.2)
 (safety-dim allowlist tracks Claude Code v2.1.126 — `.git/`,
 `.vscode/`, and a closed POSIX/zsh shell-config-file set added to
-`_is_plugin_author_write`; destructive shell forms still dock).
-Previous releases:
+`_is_plugin_author_write`),
 [v2.0.1](https://github.com/sattyamjjain/verdict/releases/tag/v2.0.1)
 (opt-in `duration_ms` enrichment + safety `.claude` path
 allowlist + marketplace validator v2.1.120 keys), and the

--- a/scripts/bench_lint.py
+++ b/scripts/bench_lint.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""Benchmark task-hygiene lint for the Verdict regression-gate corpus.
+
+Adapts the Auto Benchmark Audit (ABA) framework (Wang et al. 2026,
+arXiv:2605.26079, "Automated Benchmark Auditing for AI Agents and
+Large Language Models", v1 2026-05-25) to Verdict's transcript-
+regression manifest. ABA was designed for *task* benchmarks with
+ground-truth outputs; Verdict's benchmark pack scores transcripts
+against expected score bounds rather than tasks against expected
+answers. The four ABA issue classes map by analogy:
+
+    VBL001  SpecificationGap      -- missing name/skill, or no expected_*
+                                     assertion of any kind (case asserts
+                                     nothing about the score it produces)
+    VBL002  EnvironmentCoupling   -- transcript path absolute, escapes the
+                                     manifest dir via "..", missing on disk,
+                                     or adapter/extension mismatch
+    VBL003  BrittleGrading        -- single-point composite/grade/dim bounds
+                                     (min == max), or composite range < 0.5
+    VBL004  MissingGroundTruth    -- transcript file is 0-bytes or contains
+                                     zero non-blank lines
+
+Output: text (default), JSON (``--json``), or SARIF v2.1.0
+(``--sarif PATH``). Aggregate ``bench_hygiene_score`` =
+``1 - flagged_cases / total_cases``.
+
+Exit codes:
+    0  hygiene score >= threshold (default 0.85)
+    1  hygiene score below threshold
+    2  argument / IO error
+
+Stdlib-only. No LLM call -- the offline heuristic is the moat.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = PROJECT_ROOT / "benchmarks" / "manifest.json"
+DEFAULT_THRESHOLD = 0.85
+TOOL_NAME = "verdict-bench-lint"
+TOOL_VERSION = "2.0.3"
+TOOL_URI = "https://github.com/sattyamjjain/verdict"
+
+# Adapter -> set of allowed file suffixes. Used by VBL002 to flag
+# obvious mismatches such as adapter "openai-compatible" pointing at a
+# .jsonl file. Suffixes match how the existing corpus is laid out.
+ADAPTER_SUFFIXES: Dict[str, Tuple[str, ...]] = {
+    "claude-code": (".jsonl",),
+    "cowork": (".jsonl",),
+    "codex": (".jsonl", ".json"),
+    "openai-compatible": (".json",),
+}
+
+# Help text per rule -- echoed into SARIF rules[] and into text output.
+RULES: Dict[str, Dict[str, str]] = {
+    "VBL001": {
+        "name": "SpecificationGap",
+        "short": "Benchmark case lacks a clear spec or any score assertion.",
+        "help": (
+            "Each case should declare a non-empty 'name', a 'skill', "
+            "and at least one expected_* bound. A case with no bounds "
+            "asserts nothing -- it cannot detect a regression."
+        ),
+    },
+    "VBL002": {
+        "name": "EnvironmentCoupling",
+        "short": "Transcript path leaks the host environment or is unreachable.",
+        "help": (
+            "Transcript paths should be relative to the manifest and "
+            "stay inside the manifest directory. Absolute paths or "
+            "paths escaping via '..' make the bench environment-coupled. "
+            "Files must exist; declared adapter must match the suffix."
+        ),
+    },
+    "VBL003": {
+        "name": "BrittleGrading",
+        "short": "Grading bound is so tight that any heuristic drift fails it.",
+        "help": (
+            "Single-point bounds (min == max) and ultra-narrow composite "
+            "ranges (< 0.5) force exact-match grading where semantic match "
+            "is needed. Prefer wider bounds anchored on the dimension that "
+            "actually carries signal."
+        ),
+    },
+    "VBL004": {
+        "name": "MissingGroundTruth",
+        "short": "Transcript file is empty -- there is nothing to score.",
+        "help": (
+            "A zero-byte transcript or one with only blank lines provides "
+            "no ground truth for the scoring engine. Either delete the "
+            "case or supply a real transcript."
+        ),
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Rule implementations
+# ---------------------------------------------------------------------------
+
+_EXPECTED_KEYS = (
+    "expected_grade_min",
+    "expected_grade_max",
+    "expected_composite_min",
+    "expected_composite_max",
+    "expected_dimension_min",
+    "expected_dimension_max",
+)
+
+
+def _has_any_expected(case: Dict[str, Any]) -> bool:
+    """Return True if the case declares at least one expected_* bound."""
+    return any(k in case for k in _EXPECTED_KEYS)
+
+
+def _check_spec_gap(case: Dict[str, Any]) -> List[str]:
+    """VBL001 -- specification gaps."""
+    issues: List[str] = []
+    name = (case.get("name") or "").strip()
+    skill = (case.get("skill") or "").strip()
+    if not name:
+        issues.append("missing or empty 'name'")
+    if not skill:
+        issues.append("missing or empty 'skill'")
+    if not _has_any_expected(case):
+        issues.append("no expected_* bound declared (case asserts nothing)")
+    return issues
+
+
+def _check_env_coupling(
+    case: Dict[str, Any], manifest_dir: Path
+) -> Tuple[List[str], Optional[Path]]:
+    """VBL002 -- environment coupling. Returns (issues, resolved_path)."""
+    issues: List[str] = []
+    raw = case.get("transcript")
+    if not raw:
+        issues.append("missing 'transcript'")
+        return issues, None
+    raw_path = Path(raw)
+    if raw_path.is_absolute():
+        issues.append(f"transcript path is absolute: {raw}")
+    # Resolve and confirm it stays inside the manifest dir.
+    try:
+        resolved = (manifest_dir / raw_path).resolve()
+        manifest_root = manifest_dir.resolve()
+        # Path.is_relative_to is 3.9+, but commitment is 3.9+, so use it.
+        if not resolved.is_relative_to(manifest_root):
+            issues.append(
+                f"transcript escapes manifest dir: {raw} -> {resolved}"
+            )
+    except (OSError, RuntimeError) as exc:
+        issues.append(f"could not resolve transcript path: {exc}")
+        return issues, None
+    if not resolved.is_file():
+        issues.append(f"transcript file does not exist: {resolved}")
+    adapter = case.get("adapter")
+    if adapter:
+        allowed = ADAPTER_SUFFIXES.get(adapter)
+        if allowed and resolved.suffix not in allowed:
+            issues.append(
+                f"adapter '{adapter}' does not match suffix '{resolved.suffix}' "
+                f"(expected one of {list(allowed)})"
+            )
+    return issues, resolved
+
+
+def _check_brittle_grading(case: Dict[str, Any]) -> List[str]:
+    """VBL003 -- brittle / exact-match grading."""
+    issues: List[str] = []
+    cmin = case.get("expected_composite_min")
+    cmax = case.get("expected_composite_max")
+    if isinstance(cmin, (int, float)) and isinstance(cmax, (int, float)):
+        if cmin == cmax:
+            issues.append(
+                f"composite bounds pin a single point ({cmin}); "
+                f"any heuristic drift will fail this case"
+            )
+        elif (cmax - cmin) < 0.5:
+            issues.append(
+                f"composite range too narrow "
+                f"({cmin} <= composite <= {cmax}, width={cmax - cmin:.2f})"
+            )
+    gmin = case.get("expected_grade_min")
+    gmax = case.get("expected_grade_max")
+    if isinstance(gmin, str) and isinstance(gmax, str) and gmin == gmax:
+        issues.append(f"grade bounds pin a single letter ({gmin})")
+    dmin = case.get("expected_dimension_min") or {}
+    dmax = case.get("expected_dimension_max") or {}
+    if isinstance(dmin, dict) and isinstance(dmax, dict):
+        shared = set(dmin.keys()) & set(dmax.keys())
+        for dim in sorted(shared):
+            if dmin[dim] == dmax[dim]:
+                issues.append(
+                    f"dimension '{dim}' bounds pin a single value "
+                    f"({dmin[dim]})"
+                )
+    return issues
+
+
+def _check_missing_ground_truth(transcript: Optional[Path]) -> List[str]:
+    """VBL004 -- missing or empty transcript."""
+    if transcript is None or not transcript.is_file():
+        # VBL002 already flagged this; don't double-flag here.
+        return []
+    issues: List[str] = []
+    try:
+        size = transcript.stat().st_size
+    except OSError as exc:
+        return [f"could not stat transcript: {exc}"]
+    if size == 0:
+        return ["transcript file is 0 bytes"]
+    try:
+        text = transcript.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return [f"could not read transcript: {exc}"]
+    non_blank = [ln for ln in text.splitlines() if ln.strip()]
+    if not non_blank:
+        issues.append("transcript has no non-blank lines")
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def lint_case(
+    case: Dict[str, Any], case_index: int, manifest_dir: Path
+) -> List[Dict[str, Any]]:
+    """Run all four hygiene checks against a single case.
+
+    Returns a list of finding dicts (possibly empty). Each finding has
+    ``case_index``, ``case_name``, ``rule_id``, ``rule_name``,
+    ``severity``, and ``message`` keys.
+    """
+    findings: List[Dict[str, Any]] = []
+    name = (case.get("name") or f"<case #{case_index}>").strip() or f"<case #{case_index}>"
+
+    def _emit(rule_id: str, msg: str) -> None:
+        findings.append(
+            {
+                "case_index": case_index,
+                "case_name": name,
+                "rule_id": rule_id,
+                "rule_name": RULES[rule_id]["name"],
+                "severity": "warning",
+                "message": msg,
+            }
+        )
+
+    for msg in _check_spec_gap(case):
+        _emit("VBL001", msg)
+    env_issues, resolved = _check_env_coupling(case, manifest_dir)
+    for msg in env_issues:
+        _emit("VBL002", msg)
+    for msg in _check_brittle_grading(case):
+        _emit("VBL003", msg)
+    for msg in _check_missing_ground_truth(resolved):
+        _emit("VBL004", msg)
+    return findings
+
+
+def lint_manifest(manifest_path: Path) -> Dict[str, Any]:
+    """Lint every case in the manifest and return an aggregate report.
+
+    Report shape:
+        {
+          "manifest": "<path>",
+          "total_cases": int,
+          "flagged_cases": int,
+          "bench_hygiene_score": float,   # 0.0 - 1.0
+          "findings": [ {case_index, case_name, rule_id, ...}, ... ]
+        }
+    """
+    text = manifest_path.read_text(encoding="utf-8")
+    manifest = json.loads(text)
+    cases = manifest.get("cases", []) or []
+    manifest_dir = manifest_path.parent
+    all_findings: List[Dict[str, Any]] = []
+    flagged_indices: set = set()
+    for idx, case in enumerate(cases):
+        case_findings = lint_case(case, idx, manifest_dir)
+        if case_findings:
+            flagged_indices.add(idx)
+        all_findings.extend(case_findings)
+    total = len(cases)
+    flagged = len(flagged_indices)
+    score = 1.0 if total == 0 else 1.0 - (flagged / total)
+    return {
+        "manifest": str(manifest_path),
+        "total_cases": total,
+        "flagged_cases": flagged,
+        "bench_hygiene_score": round(score, 4),
+        "findings": all_findings,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output renderers
+# ---------------------------------------------------------------------------
+
+
+def render_text(report: Dict[str, Any], threshold: float) -> str:
+    """Render a Unicode-box text report matching the project's house style."""
+    width = 70
+
+    def row(s: str) -> str:
+        # Truncate if too long, pad otherwise.
+        s = s[:width] if len(s) > width else s
+        return "│" + s.ljust(width) + "│"
+
+    lines: List[str] = []
+    score = report["bench_hygiene_score"]
+    total = report["total_cases"]
+    flagged = report["flagged_cases"]
+    verdict = "PASS" if score >= threshold else "FAIL"
+    lines.append("┌" + "─" * width + "┐")
+    lines.append(row("  VERDICT BENCH-LINT (ABA-anchored, arXiv:2605.26079)"))
+    lines.append("├" + "─" * width + "┤")
+    lines.append(row(f"  Manifest: {Path(report['manifest']).name}"))
+    lines.append(row(f"  Cases:    {total} total, {flagged} flagged"))
+    lines.append(
+        row(
+            f"  Score:    bench_hygiene_score = {score:.4f}  "
+            f"(threshold {threshold:.2f}) -> {verdict}"
+        )
+    )
+    lines.append("└" + "─" * width + "┘")
+    if report["findings"]:
+        lines.append("")
+        lines.append("Findings:")
+        last_case = None
+        for f in report["findings"]:
+            if f["case_name"] != last_case:
+                lines.append(f"  [{f['case_name']}]")
+                last_case = f["case_name"]
+            lines.append(
+                f"    {f['rule_id']} {f['rule_name']}: {f['message']}"
+            )
+    return "\n".join(lines)
+
+
+def to_sarif(report: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a report to a SARIF v2.1.0 log."""
+    manifest_uri = Path(report["manifest"]).name
+    rules = []
+    for rid, meta in sorted(RULES.items()):
+        rules.append(
+            {
+                "id": rid,
+                "name": meta["name"],
+                "shortDescription": {"text": meta["short"]},
+                "fullDescription": {"text": meta["help"]},
+                "helpUri": TOOL_URI,
+                "defaultConfiguration": {"level": "warning"},
+            }
+        )
+    results = []
+    for f in report["findings"]:
+        results.append(
+            {
+                "ruleId": f["rule_id"],
+                "level": f["severity"],
+                "message": {
+                    "text": f"[{f['case_name']}] {f['message']}"
+                },
+                "locations": [
+                    {
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": manifest_uri},
+                        },
+                        "logicalLocations": [
+                            {
+                                "name": f["case_name"],
+                                "kind": "object",
+                                "fullyQualifiedName": f"cases[{f['case_index']}]",
+                            }
+                        ],
+                    }
+                ],
+                "properties": {
+                    "bench_hygiene_score": report["bench_hygiene_score"],
+                },
+            }
+        )
+    return {
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": TOOL_NAME,
+                        "version": TOOL_VERSION,
+                        "informationUri": TOOL_URI,
+                        "rules": rules,
+                    }
+                },
+                "results": results,
+                "properties": {
+                    "manifest": report["manifest"],
+                    "total_cases": report["total_cases"],
+                    "flagged_cases": report["flagged_cases"],
+                    "bench_hygiene_score": report["bench_hygiene_score"],
+                },
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        prog="bench_lint",
+        description=(
+            "ABA-anchored task-hygiene lint for Verdict's benchmark pack. "
+            "Offline, stdlib-only, no LLM call."
+        ),
+    )
+    parser.add_argument(
+        "manifest",
+        nargs="?",
+        default=str(DEFAULT_MANIFEST),
+        help="Path to manifest.json (default: benchmarks/manifest.json)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=DEFAULT_THRESHOLD,
+        help=f"Pass bench_hygiene_score (default {DEFAULT_THRESHOLD})",
+    )
+    parser.add_argument(
+        "--json",
+        dest="emit_json",
+        action="store_true",
+        help="Emit the full report as JSON to stdout instead of text.",
+    )
+    parser.add_argument(
+        "--sarif",
+        metavar="PATH",
+        help="Write SARIF v2.1.0 output to PATH (text summary still printed).",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress text output (useful in CI when --sarif is set).",
+    )
+    return parser.parse_args(argv[1:])
+
+
+def main(argv: List[str]) -> int:
+    """Run the lint and return an exit code."""
+    args = parse_args(argv)
+    manifest_path = Path(args.manifest)
+    if not manifest_path.is_file():
+        print(f"Error: manifest not found at {manifest_path}", file=sys.stderr)
+        return 2
+    try:
+        report = lint_manifest(manifest_path)
+    except json.JSONDecodeError as exc:
+        print(f"Error: manifest is not valid JSON: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"Error: could not read manifest: {exc}", file=sys.stderr)
+        return 2
+
+    if args.sarif:
+        sarif = to_sarif(report)
+        try:
+            Path(args.sarif).write_text(
+                json.dumps(sarif, indent=2) + "\n", encoding="utf-8"
+            )
+        except OSError as exc:
+            print(f"Error: could not write SARIF to {args.sarif}: {exc}", file=sys.stderr)
+            return 2
+
+    if args.emit_json:
+        print(json.dumps(report, indent=2))
+    elif not args.quiet:
+        print(render_text(report, args.threshold))
+
+    return 0 if report["bench_hygiene_score"] >= args.threshold else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/benchmark_pack.py
+++ b/scripts/benchmark_pack.py
@@ -5,13 +5,22 @@ assert each case satisfies its expected bounds. Exits 1 on any failure.
 Used by CI to catch heuristic regressions before they ship. Stdlib-only.
 
 Usage:
-    python3 scripts/benchmark_pack.py [manifest_path]
+    python3 scripts/benchmark_pack.py [manifest_path] [--lint] [--sarif PATH]
+                                       [--hygiene-threshold FLOAT]
 
-If omitted, defaults to ``benchmarks/manifest.json`` relative to the
-project root.
+If omitted, the manifest defaults to ``benchmarks/manifest.json`` relative
+to the project root.
+
+``--lint`` runs the ABA-anchored hygiene lint as a pre-flight gate. If
+``bench_hygiene_score`` falls below ``--hygiene-threshold`` (default
+0.85), the run aborts before any score is consumed -- CI surfaces "this
+benchmark may not be trustworthy" instead of greenwashing a suspect
+corpus. ``--sarif PATH`` writes a SARIF v2.1.0 report of the lint
+findings to PATH.
 """
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 import tempfile
@@ -25,6 +34,10 @@ CONFIG_PATH = PROJECT_ROOT / "judge-config.json"
 
 sys.path.insert(0, str(SCORE_PY.parent))
 import score  # noqa: E402  -- must follow sys.path manipulation
+
+# bench_lint lives in this same scripts/ directory.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import bench_lint  # noqa: E402
 
 # A→F in descending order so "grade_min: B" accepts A-, A, A+ but not B-
 GRADE_ORDER: List[str] = [
@@ -83,11 +96,92 @@ def _check(case: Dict[str, Any], scorecard: Dict[str, Any]) -> Tuple[bool, List[
     return not errors, errors
 
 
+def _parse_args(argv: List[str]) -> argparse.Namespace:
+    """Parse CLI arguments, keeping the legacy positional manifest path."""
+    parser = argparse.ArgumentParser(
+        prog="benchmark_pack",
+        description=(
+            "Run the regression-gate corpus through the scoring engine. "
+            "Add --lint for an ABA-anchored hygiene pre-flight gate."
+        ),
+    )
+    parser.add_argument(
+        "manifest",
+        nargs="?",
+        default=str(PROJECT_ROOT / "benchmarks" / "manifest.json"),
+        help="Path to manifest.json (default: benchmarks/manifest.json)",
+    )
+    parser.add_argument(
+        "--lint",
+        action="store_true",
+        help="Run bench_lint as a pre-flight gate before the regression suite.",
+    )
+    parser.add_argument(
+        "--sarif",
+        metavar="PATH",
+        help="Write SARIF v2.1.0 lint output to PATH (implies --lint).",
+    )
+    parser.add_argument(
+        "--hygiene-threshold",
+        type=float,
+        default=bench_lint.DEFAULT_THRESHOLD,
+        help=(
+            f"bench_hygiene_score threshold for --lint "
+            f"(default {bench_lint.DEFAULT_THRESHOLD})"
+        ),
+    )
+    return parser.parse_args(argv[1:])
+
+
+def _run_lint_gate(
+    manifest_path: Path, sarif_path: str | None, threshold: float
+) -> int:
+    """Run the hygiene lint as a pre-flight gate. Return an exit code."""
+    print(f"Pre-flight: bench_lint (ABA-anchored, threshold {threshold:.2f})...")
+    report = bench_lint.lint_manifest(manifest_path)
+    if sarif_path:
+        sarif = bench_lint.to_sarif(report)
+        Path(sarif_path).write_text(
+            json.dumps(sarif, indent=2) + "\n", encoding="utf-8"
+        )
+        print(f"  SARIF written to {sarif_path}")
+    score_val = report["bench_hygiene_score"]
+    flagged = report["flagged_cases"]
+    total = report["total_cases"]
+    if score_val < threshold:
+        print(
+            f"  ✗ bench_hygiene_score={score_val:.4f} below "
+            f"threshold {threshold:.2f} ({flagged}/{total} cases flagged) "
+            f"-- corpus may not be trustworthy",
+            file=sys.stderr,
+        )
+        for f in report["findings"]:
+            print(
+                f"    {f['rule_id']} [{f['case_name']}]: {f['message']}",
+                file=sys.stderr,
+            )
+        return 1
+    print(
+        f"  ✓ bench_hygiene_score={score_val:.4f} "
+        f"({flagged}/{total} cases flagged)"
+    )
+    return 0
+
+
 def main(argv: List[str]) -> int:
-    manifest_path = Path(argv[1]) if len(argv) > 1 else PROJECT_ROOT / "benchmarks" / "manifest.json"
+    """CLI entry point."""
+    args = _parse_args(argv)
+    manifest_path = Path(args.manifest)
     if not manifest_path.is_file():
         print(f"Error: manifest not found at {manifest_path}", file=sys.stderr)
         return 2
+
+    # --sarif implies --lint (no value running SARIF if we never linted).
+    run_lint = args.lint or bool(args.sarif)
+    if run_lint:
+        code = _run_lint_gate(manifest_path, args.sarif, args.hygiene_threshold)
+        if code != 0:
+            return code
 
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     cases = manifest.get("cases", [])

--- a/skills/judge/SKILL.md
+++ b/skills/judge/SKILL.md
@@ -2,7 +2,7 @@
 name: judge
 displayName: "Verdict — Universal Quality Evaluator"
 description: "Evaluates the execution quality of any skill or agent using 7-dimension scoring with configurable rubrics"
-version: "2.0.2"
+version: "2.0.3"
 author: "Sattyam Jain"
 allowed-tools: [Read, Write, Edit, Bash]
 autoActivate:

--- a/tests/test_bench_lint.py
+++ b/tests/test_bench_lint.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+"""Tests for scripts/bench_lint.py and the --lint wire into benchmark_pack.
+
+The lint adapts the Auto Benchmark Audit framework (Wang et al. 2026,
+arXiv:2605.26079) to Verdict's transcript-regression manifest. These
+tests verify that:
+
+1. The shipped benchmarks/manifest.json passes hygiene cleanly
+   (bench_hygiene_score == 1.0, exit 0).
+2. Each of the four hygiene rule classes (VBL001-004) fires on an
+   injected bad case.
+3. SARIF output is valid v2.1.0 shape with one result per finding.
+4. Exit codes follow the contract: 0 above threshold, 1 below, 2 on
+   IO/arg failure.
+5. The benchmark_pack --lint pre-flight gate aborts before the
+   regression suite runs when the corpus is below threshold.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Dict, List
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = PROJECT_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import bench_lint as bl  # noqa: E402  -- must follow sys.path manipulation
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_manifest(tmp: Path, cases: List[Dict[str, Any]]) -> Path:
+    """Write a tiny manifest + populate transcript files referenced by cases.
+
+    Any case carrying ``_make_transcript`` is materialised on disk with
+    that content (and the helper key stripped before write).
+    """
+    cleaned: List[Dict[str, Any]] = []
+    for case in cases:
+        case = dict(case)
+        body = case.pop("_make_transcript", None)
+        if body is not None and case.get("transcript"):
+            (tmp / case["transcript"]).parent.mkdir(parents=True, exist_ok=True)
+            (tmp / case["transcript"]).write_text(body, encoding="utf-8")
+        cleaned.append(case)
+    manifest = {"description": "test fixture", "cases": cleaned}
+    path = tmp / "manifest.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+    return path
+
+
+_GOOD_TRANSCRIPT = (
+    '{"role":"user","content":"hi"}\n'
+    '{"role":"assistant","content":"hello"}\n'
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for individual rules
+# ---------------------------------------------------------------------------
+
+
+class TestSpecGap(unittest.TestCase):
+    def test_missing_name_flags_VBL001(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            mp = _write_manifest(
+                tmp_path,
+                [
+                    {
+                        "name": "",
+                        "skill": "code-review",
+                        "transcript": "t.jsonl",
+                        "expected_composite_min": 7.0,
+                        "_make_transcript": _GOOD_TRANSCRIPT,
+                    }
+                ],
+            )
+            report = bl.lint_manifest(mp)
+            rule_ids = {f["rule_id"] for f in report["findings"]}
+            self.assertIn("VBL001", rule_ids)
+
+    def test_missing_skill_flags_VBL001(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            mp = _write_manifest(
+                tmp_path,
+                [
+                    {
+                        "name": "no-skill",
+                        "transcript": "t.jsonl",
+                        "expected_composite_min": 7.0,
+                        "_make_transcript": _GOOD_TRANSCRIPT,
+                    }
+                ],
+            )
+            self.assertIn(
+                "VBL001",
+                {f["rule_id"] for f in bl.lint_manifest(mp)["findings"]},
+            )
+
+    def test_no_expected_assertion_flags_VBL001(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            mp = _write_manifest(
+                tmp_path,
+                [
+                    {
+                        "name": "nothing-asserted",
+                        "skill": "code-review",
+                        "transcript": "t.jsonl",
+                        "_make_transcript": _GOOD_TRANSCRIPT,
+                    }
+                ],
+            )
+            report = bl.lint_manifest(mp)
+            self.assertIn(
+                "VBL001",
+                {f["rule_id"] for f in report["findings"]},
+            )
+
+
+class TestEnvCoupling(unittest.TestCase):
+    def test_absolute_transcript_path_flags_VBL002(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            absolute = tmp_path / "abs.jsonl"
+            absolute.write_text(_GOOD_TRANSCRIPT, encoding="utf-8")
+            mp = _write_manifest(
+                tmp_path,
+                [
+                    {
+                        "name": "absolute-leak",
+                        "skill": "code-review",
+                        "transcript": str(absolute),
+                        "expected_composite_min": 7.0,
+                    }
+                ],
+            )
+            self.assertIn(
+                "VBL002",
+                {f["rule_id"] for f in bl.lint_manifest(mp)["findings"]},
+            )
+
+    def test_missing_transcript_flags_VBL002(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            mp = _write_manifest(
+                tmp_path,
+                [
+                    {
+                        "name": "ghost",
+                        "skill": "code-review",
+                        "transcript": "does-not-exist.jsonl",
+                        "expected_composite_min": 7.0,
+                    }
+                ],
+            )
+            self.assertIn(
+                "VBL002",
+                {f["rule_id"] for f in bl.lint_manifest(mp)["findings"]},
+            )
+
+    def test_adapter_extension_mismatch_flags_VBL002(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            mp = _write_manifest(
+                tmp_path,
+                [
+                    {
+                        "name": "openai-but-jsonl",
+                        "skill": "code-review",
+                        "transcript": "wrong.jsonl",
+                        "adapter": "openai-compatible",
+                        "expected_composite_min": 7.0,
+                        "_make_transcript": _GOOD_TRANSCRIPT,
+                    }
+                ],
+            )
+            self.assertIn(
+                "VBL002",
+                {f["rule_id"] for f in bl.lint_manifest(mp)["findings"]},
+            )
+
+
+class TestBrittleGrading(unittest.TestCase):
+    def test_single_point_composite_flags_VBL003(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            mp = _write_manifest(
+                tmp_path,
+                [
+                    {
+                        "name": "pin-composite",
+                        "skill": "code-review",
+                        "transcript": "t.jsonl",
+                        "expected_composite_min": 8.0,
+                        "expected_composite_max": 8.0,
+                        "_make_transcript": _GOOD_TRANSCRIPT,
+                    }
+                ],
+            )
+            self.assertIn(
+                "VBL003",
+                {f["rule_id"] for f in bl.lint_manifest(mp)["findings"]},
+            )
+
+    def test_narrow_composite_range_flags_VBL003(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            mp = _write_manifest(
+                tmp_path,
+                [
+                    {
+                        "name": "narrow",
+                        "skill": "code-review",
+                        "transcript": "t.jsonl",
+                        "expected_composite_min": 8.0,
+                        "expected_composite_max": 8.2,
+                        "_make_transcript": _GOOD_TRANSCRIPT,
+                    }
+                ],
+            )
+            self.assertIn(
+                "VBL003",
+                {f["rule_id"] for f in bl.lint_manifest(mp)["findings"]},
+            )
+
+    def test_pinned_dimension_flags_VBL003(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            mp = _write_manifest(
+                tmp_path,
+                [
+                    {
+                        "name": "pin-dim",
+                        "skill": "code-review",
+                        "transcript": "t.jsonl",
+                        "expected_dimension_min": {"safety": 9},
+                        "expected_dimension_max": {"safety": 9},
+                        "_make_transcript": _GOOD_TRANSCRIPT,
+                    }
+                ],
+            )
+            self.assertIn(
+                "VBL003",
+                {f["rule_id"] for f in bl.lint_manifest(mp)["findings"]},
+            )
+
+
+class TestMissingGroundTruth(unittest.TestCase):
+    def test_empty_file_flags_VBL004(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            mp = _write_manifest(
+                tmp_path,
+                [
+                    {
+                        "name": "empty-transcript",
+                        "skill": "code-review",
+                        "transcript": "empty.jsonl",
+                        "expected_composite_min": 7.0,
+                        "_make_transcript": "",
+                    }
+                ],
+            )
+            rule_ids = {f["rule_id"] for f in bl.lint_manifest(mp)["findings"]}
+            self.assertIn("VBL004", rule_ids)
+
+    def test_blank_only_file_flags_VBL004(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            mp = _write_manifest(
+                tmp_path,
+                [
+                    {
+                        "name": "blank-lines-only",
+                        "skill": "code-review",
+                        "transcript": "blank.jsonl",
+                        "expected_composite_min": 7.0,
+                        "_make_transcript": "\n\n   \n\t\n",
+                    }
+                ],
+            )
+            self.assertIn(
+                "VBL004",
+                {f["rule_id"] for f in bl.lint_manifest(mp)["findings"]},
+            )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestShippedManifestIsClean(unittest.TestCase):
+    """The repo's own benchmarks/manifest.json must pass the lint."""
+
+    def test_shipped_manifest_scores_1_0(self) -> None:
+        report = bl.lint_manifest(PROJECT_ROOT / "benchmarks" / "manifest.json")
+        self.assertEqual(report["flagged_cases"], 0, report["findings"])
+        self.assertEqual(report["bench_hygiene_score"], 1.0)
+
+    def test_shipped_manifest_exit_0(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / "bench_lint.py"), "--quiet"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+class TestHygieneScoreAggregate(unittest.TestCase):
+    def test_one_bad_out_of_two_scores_0_5(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            mp = _write_manifest(
+                tmp_path,
+                [
+                    {
+                        "name": "clean",
+                        "skill": "code-review",
+                        "transcript": "good.jsonl",
+                        "expected_composite_min": 7.0,
+                        "_make_transcript": _GOOD_TRANSCRIPT,
+                    },
+                    {
+                        "name": "bad",
+                        "skill": "code-review",
+                        "transcript": "empty.jsonl",
+                        "expected_composite_min": 7.0,
+                        "_make_transcript": "",
+                    },
+                ],
+            )
+            report = bl.lint_manifest(mp)
+            self.assertEqual(report["total_cases"], 2)
+            self.assertEqual(report["flagged_cases"], 1)
+            self.assertEqual(report["bench_hygiene_score"], 0.5)
+
+
+class TestSarifShape(unittest.TestCase):
+    def test_sarif_has_v2_1_0_envelope(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            mp = _write_manifest(
+                tmp_path,
+                [
+                    {
+                        "name": "bad",
+                        "skill": "code-review",
+                        "transcript": "empty.jsonl",
+                        "expected_composite_min": 7.0,
+                        "_make_transcript": "",
+                    }
+                ],
+            )
+            report = bl.lint_manifest(mp)
+            sarif = bl.to_sarif(report)
+            self.assertEqual(sarif["version"], "2.1.0")
+            self.assertEqual(len(sarif["runs"]), 1)
+            run = sarif["runs"][0]
+            self.assertEqual(
+                run["tool"]["driver"]["name"], "verdict-bench-lint"
+            )
+            rule_ids = [r["id"] for r in run["tool"]["driver"]["rules"]]
+            self.assertEqual(
+                sorted(rule_ids), ["VBL001", "VBL002", "VBL003", "VBL004"]
+            )
+            # Exactly one result per finding (the empty file fires VBL004).
+            self.assertEqual(len(run["results"]), len(report["findings"]))
+            self.assertGreaterEqual(len(run["results"]), 1)
+            self.assertEqual(run["results"][0]["ruleId"], "VBL004")
+
+
+class TestCLIExitCodes(unittest.TestCase):
+    def _run(self, *args: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / "bench_lint.py"), *args],
+            capture_output=True,
+            text=True,
+            cwd=str(cwd) if cwd else None,
+        )
+
+    def test_exit_2_when_manifest_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self._run(str(Path(tmp) / "nope.json"))
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("not found", result.stderr)
+
+    def test_exit_2_when_manifest_invalid_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bad = Path(tmp) / "bad.json"
+            bad.write_text("{not json", encoding="utf-8")
+            result = self._run(str(bad))
+            self.assertEqual(result.returncode, 2)
+
+    def test_exit_1_when_below_threshold(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            mp = _write_manifest(
+                tmp_path,
+                [
+                    {
+                        "name": "bad",
+                        "skill": "code-review",
+                        "transcript": "empty.jsonl",
+                        "expected_composite_min": 7.0,
+                        "_make_transcript": "",
+                    }
+                ],
+            )
+            result = self._run(str(mp), "--quiet")
+            self.assertEqual(result.returncode, 1, result.stderr)
+
+    def test_exit_0_when_above_threshold(self) -> None:
+        result = self._run(
+            str(PROJECT_ROOT / "benchmarks" / "manifest.json"), "--quiet"
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_sarif_file_written(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            mp = _write_manifest(
+                tmp_path,
+                [
+                    {
+                        "name": "bad",
+                        "skill": "code-review",
+                        "transcript": "empty.jsonl",
+                        "expected_composite_min": 7.0,
+                        "_make_transcript": "",
+                    }
+                ],
+            )
+            sarif_path = tmp_path / "out.sarif"
+            result = self._run(str(mp), "--sarif", str(sarif_path), "--quiet")
+            self.assertEqual(result.returncode, 1)
+            self.assertTrue(sarif_path.is_file())
+            doc = json.loads(sarif_path.read_text(encoding="utf-8"))
+            self.assertEqual(doc["version"], "2.1.0")
+
+
+class TestBenchmarkPackLintGate(unittest.TestCase):
+    """The ship-gate: benchmark_pack --lint aborts when corpus is suspect."""
+
+    def test_lint_gate_aborts_on_dirty_corpus(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            mp = _write_manifest(
+                tmp_path,
+                [
+                    {
+                        "name": "bad",
+                        "skill": "code-review",
+                        "transcript": "empty.jsonl",
+                        "expected_composite_min": 7.0,
+                        "_make_transcript": "",
+                    }
+                ],
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPTS_DIR / "benchmark_pack.py"),
+                    str(mp),
+                    "--lint",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            # Pre-flight must abort BEFORE the regression suite starts.
+            self.assertIn("Pre-flight", result.stdout)
+            self.assertNotIn("Running 1 benchmark case", result.stdout)
+            self.assertIn("VBL004", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `scripts/bench_lint.py` — an offline, stdlib-only audit of the
regression-gate manifest itself, anchored on the **Auto Benchmark Audit
(ABA)** framework (Wang et al. 2026, [arXiv:2605.26079](https://arxiv.org/abs/2605.26079),
*"Automated Benchmark Auditing for AI Agents and Large Language Models"*,
v1 2026-05-25). ABA found that ~25.7% of tasks across 168 benchmarks
contained one of four issue classes, and that removing them moved model
scores by ~9.6–9.9%. The lint catches the same *shape* of issue in our
own pack **before** CI greenwashes a suspect corpus.

## What changed

**Lint engine** (`scripts/bench_lint.py`, new, stdlib-only, 496 lines):

| Rule  | Class | Triggers |
|-------|-------|----------|
| **VBL001** | SpecificationGap | missing `name`/`skill`, or no `expected_*` bound declared (case asserts nothing) |
| **VBL002** | EnvironmentCoupling | absolute transcript path, escapes manifest dir via `..`, transcript missing, or `adapter` ↔ suffix mismatch |
| **VBL003** | BrittleGrading | single-point composite/grade/dim bounds (`min == max`), or composite range < 0.5 |
| **VBL004** | MissingGroundTruth | transcript is 0-bytes or contains zero non-blank lines |

- Aggregate `bench_hygiene_score = 1 - flagged_cases / total_cases`
- Output: text (default), JSON (`--json`), SARIF v2.1.0 (`--sarif PATH`)
- Exit codes: **0** above threshold (default 0.85), **1** below, **2** on IO/arg failure
- **No LLM call** — the offline heuristic is the moat

**Ship-gate wire-up** (`scripts/benchmark_pack.py`):

- `--lint` runs the hygiene pre-flight *before* the regression suite
- `--sarif PATH` writes SARIF v2.1.0 (implies `--lint`)
- `--hygiene-threshold FLOAT` overrides the default 0.85
- If the gate fails, the regression suite is skipped and CI surfaces *"this benchmark may not be trustworthy"* instead of consuming suspect scores
- Legacy positional manifest argument preserved

**Version bump**: `v2.0.2 → v2.0.3`, synced across `plugin.json`,
`marketplace.json`, `SKILL.md` frontmatter, and the CHANGELOG release
heading (pinned by `tests/test_version_consistency.py`).

**Docs**: README gets a dedicated `## Benchmark hygiene lint
(ABA-anchored)` section with the arXiv citation, rule table, usage
examples, and the scope-honesty note. Release anchor moved to v2.0.3
(pinned by `tests/test_readme_release_anchor.py`). CHANGELOG entry
under `## [2.0.3] - 2026-05-28` with the O17 follow-up.

## Test plan

```shell
python3 -m unittest discover tests/ -v         # 562 tests pass
python3 scripts/bench_lint.py                  # shipped manifest scores 1.0 / exit 0
python3 scripts/benchmark_pack.py --lint       # pre-flight clean, regression green
python3 scripts/benchmark_pack.py --sarif /tmp/bp.sarif  # SARIF written + lint passes
python3 scripts/check_readme_release_anchor.py # README anchor matches CHANGELOG
```

New `tests/test_bench_lint.py` (21 tests):

- shipped `benchmarks/manifest.json` scores 1.0 / exits 0
- each of **VBL001–004** fires on an injected bad case
- SARIF v2.1.0 envelope + rule inventory pinned
- exit-code matrix (0 above / 1 below / 2 IO-or-arg) verified
- `benchmark_pack --lint` aborts *before* the regression suite when
  corpus is dirty, surfaces the VBL ruleId in stderr

## Scope honesty

Verdict's "benchmark pack" scores **transcripts** against expected
score bounds, not **tasks** against ground-truth outputs
(`benchmarks/manifest.json` is explicitly *not* a public eval bench —
see `benchmarks/README.md`). The four ABA classes therefore apply
**by analogy**, mapped to the regression-gate shape. Both the lint
output and the README state this adaptation explicitly so nobody
reads it as a 1:1 ABA implementation. Tracked as **O17** in the
CHANGELOG for a future literal pass if Verdict ever grows a true
task benchmark.

## No-pivot guardrails (preserved)

- ✅ **Stdlib-only** — no `requests`, no `anthropic`, no third-party imports. SARIF is hand-emitted JSON.
- ✅ **LLM judging stays opt-in / off-by-default** — this is offline-only.
- ✅ **Verdict still scores executions/tasks, not models.**

## Drive-by

The first commit on this branch (`docs: refresh CLAUDE.md
auto-managed sections via /init`) is a separate concern: it lands
the refreshed AUTO-MANAGED blocks in `CLAUDE.md` that the v2.0.0
trim outdated. Manual blocks (Overview, v4.3 Scope Contract, Code
Conventions, Custom Notes) preserved verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)