### PR TITLE
feat(consistency): verifier-collapse detector for /judge --explain + ship-gate (v2.0.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "verdict",
       "source": "./",
       "description": "Auto-evaluates skill and agent execution quality with 7-dimension scoring, configurable rubrics, and dual-mode operation.",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "category": "quality-assurance",
       "tags": ["judge", "evaluation", "quality", "scoring", "LLM-as-judge"],
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verdict",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "displayName": "Verdict — Universal Skill & Agent Quality Judge",
   "description": "The first universal judge for Claude Code & Cowork. Auto-evaluates skill and agent execution quality with 7-dimension scoring, configurable rubrics, and dual-mode operation (auto hooks + manual /judge command).",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,87 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   BrowseComp-Plus (2026-05-06), Managed Agents Outcomes rubric
   beta (2026-05-09).
 
+## [2.0.4] - 2026-05-29
+
+Patch release. Adds a stdlib-only verifier-collapse detector to the
+consistency dimension and wires the resulting flag into both the
+`/judge --explain` output (Markdown + `explain.v1` JSON) and the
+Stop-hook ship-gate. Closes a latent bug in
+`_analyze_consistency`: the prior low-variance branch would
+*reward* a flatlined verifier with a `+1` "highly consistent"
+bonus — the new detector composes with that path so collapsed
+verifiers net to a dock instead.
+
+### Added
+
+- `skills/judge/scripts/score.py::_detect_verifier_collapse` —
+  offline statistics over the rolling window of recent scorecards
+  for the same skill. Flags `verifier_collapse=true` when, over at
+  least `min_samples` of the last `window` cards (defaults 5/10):
+    * fraction of composites `>= top_threshold` (default 8.5)
+      crosses `top_bucket_fraction` (default 0.95), **and**
+    * `std_dev` of composites `< max_std_dev` (default 0.3 —
+      tighter than the existing 0.8 "highly consistent" cutoff).
+
+  On a hit, `_analyze_consistency` docks the dimension by
+  `consistency_dock` (default 3) and appends a one-line reason.
+  The dock is wide enough to net out the existing low-variance
+  `+1` bonus that the same data would otherwise trigger.
+
+- `dimensions.consistency.verifier_collapse` /
+  `verifier_collapse_reason` / `verifier_collapse_stats` on the
+  scorecard, mirrored at the scorecard top level as
+  `verifier_collapse: bool` for one-jq-query CI consumption.
+
+- `judge-config.json.verifier_collapse` block (enabled by default;
+  set `enabled: false` to disable). Knobs: `window`, `min_samples`,
+  `top_threshold`, `top_bucket_fraction`, `max_std_dev`,
+  `consistency_dock`, `gate_mode`.
+
+- `explain.v1` JSON surfaces `verifier_collapse` (top-level) plus
+  per-dimension `verifier_collapse` / `verifier_collapse_reason` /
+  `verifier_collapse_stats` on the consistency entry. The Markdown
+  renderer adds a "⚠️ Verifier collapse detected" callout above
+  the dimension table, anchored on Verdict's own consistency
+  dimension plus the Soft-SVeRL project anchor (no sibling
+  benchmark analogies, per the G13 cross-pollination rule).
+
+- `hooks/judge-on-stop.sh` honours
+  `judge-config.json.verifier_collapse.gate_mode`:
+    * `warn` (default) — stderr `Verdict WARNING: verifier collapse
+      detected for $SKILL_NAME — $REASON`, exit code unchanged.
+    * `fail` — stderr `Verdict BLOCKED: ...` + `exit 2` (same shape
+      as the existing threshold-breach gate).
+    * `off` — silent.
+
+- `schemas/scorecard.v1.schema.json` now declares the new optional
+  fields (top-level `verifier_collapse` plus the three new
+  per-dimension keys). Backward-compatible additive extension; no
+  required-field change.
+
+### Tests
+
+- `tests/test_verifier_collapse.py` (new): clean varied history
+  produces no flag; collapsed history (10× 9.5) flags + docks the
+  consistency dim; below-`min_samples` produces no flag;
+  `enabled: false` produces no flag; explain.v1 JSON carries
+  top-level + per-dim fields; Markdown renderer emits the callout
+  with the Soft-SVeRL anchor; hook gate-mode `warn` exits 0,
+  `fail` exits 2, `off` is silent.
+
+### Notes
+
+- The detector is **offline-only** (pure stdlib statistics over
+  `scores/`) and is the default-on companion to the off-by-default
+  LLM second-opinion analyzer. LLM judging is not made the default
+  by this change — the offline heuristic is the moat.
+
+- The signal is **derived from Verdict's own consistency dimension
+  plus the Soft-SVeRL project anchor**. Sibling-benchmark analogies
+  were considered and dropped per the G13 anti-cross-pollination
+  rule; no external evaluation suites are named in code, docs, or
+  CHANGELOG for this change.
+
 ## [2.0.3] - 2026-05-28
 
 Patch release. Adds an ABA-anchored task-hygiene lint to the

--- a/README.md
+++ b/README.md
@@ -344,15 +344,72 @@ adaptation explicit. If Verdict ever grows a true task benchmark,
 the rules will need a literal pass — tracked as **O17** in
 `CHANGELOG.md`.
 
+## Verifier-collapse detector
+
+`_analyze_consistency` already compares each run against the rolling
+history of recent scorecards for the same skill — but the existing
+low-variance branch *rewards* `std_dev <= 0.8` with a `+1` "highly
+consistent" bonus. That branch silently rewards the failure mode
+where a judge has flatlined at the top of the scale.
+
+The verifier-collapse detector (`v2.0.4+`, offline, stdlib-only)
+composes with that path. Over the rolling window of recent
+scorecards for the same skill, it flags `verifier_collapse=true`
+when **both**:
+
+| Condition | Default |
+|-----------|---------|
+| fraction of composites `>= top_threshold` exceeds `top_bucket_fraction` | `>= 8.5` for `>= 95%` of cards |
+| `std_dev` of those composites falls below `max_std_dev` | `< 0.3` (tighter than the existing 0.8 "highly consistent" cutoff) |
+| at least `min_samples` of the last `window` cards available | `5 of 10` |
+
+On a hit, the consistency dimension is docked by `consistency_dock`
+(default `3`) — wide enough to net out the existing `+1` low-variance
+bonus that the same data would otherwise trigger. The boolean is
+mirrored at the scorecard top level for one-jq-query CI consumption,
+surfaced in the `/judge --explain` Markdown as a `⚠️ Verifier
+collapse detected` callout above the dimension table, and added to
+the `explain.v1` JSON payload at both top-level (`verifier_collapse`)
+and per-dimension (`dimensions.consistency.verifier_collapse` +
+`verifier_collapse_reason` + `verifier_collapse_stats`) levels.
+
+```shell
+# Disable the detector entirely:
+jq '.verifier_collapse.enabled = false' judge-config.json > tmp && mv tmp judge-config.json
+
+# Demote the ship-gate from blocking to a stderr warning (default):
+jq '.verifier_collapse.gate_mode = "warn"' judge-config.json > tmp && mv tmp judge-config.json
+
+# Block the Stop hook (exit 2) when a collapse is detected:
+jq '.verifier_collapse.gate_mode = "fail"' judge-config.json > tmp && mv tmp judge-config.json
+```
+
+The `judge-on-stop.sh` ship-gate honours `gate_mode` ∈
+`{"warn", "fail", "off"}` and emits
+`Verdict {WARNING,BLOCKED}: verifier collapse detected for <skill>`
+on stderr.
+
+**Anchor.** The signal is derived from Verdict's own consistency
+dimension plus the **Soft-SVeRL** project anchor — distinct from
+variance-based consistency, not a sibling-benchmark analogy. The
+heuristic is offline statistics, default-on, and never calls an
+LLM; this complements (does not replace) the opt-in LLM
+second-opinion analyzer.
+
 ## Roadmap
 
 See [ROADMAP_2026.md](ROADMAP_2026.md) for the 90-day plan. Latest
-release: [v2.0.3](https://github.com/sattyamjjain/verdict/releases/tag/v2.0.3)
+release: [v2.0.4](https://github.com/sattyamjjain/verdict/releases/tag/v2.0.4)
+(verifier-collapse detector — flags judges that have flatlined at
+the top of the scale over the rolling scorecard window, docks the
+consistency dim, surfaces in `/judge --explain` + the Stop-hook
+ship-gate; offline stdlib-only, default-on).
+Previous releases:
+[v2.0.3](https://github.com/sattyamjjain/verdict/releases/tag/v2.0.3)
 (ABA-anchored benchmark hygiene lint + ship-gate wire-up — flags
 spec gaps, env coupling, brittle grading, and missing ground truth
 in the regression-gate manifest *before* its scores ship; SARIF
-output for CI surfacing).
-Previous releases:
+output for CI surfacing),
 [v2.0.2](https://github.com/sattyamjjain/verdict/releases/tag/v2.0.2)
 (safety-dim allowlist tracks Claude Code v2.1.126 — `.git/`,
 `.vscode/`, and a closed POSIX/zsh shell-config-file set added to

--- a/hooks/common.sh
+++ b/hooks/common.sh
@@ -120,3 +120,13 @@ get_threshold() {
   local config_path="$1"
   jq -r '.auto_judge.threshold // 5.0' "$config_path" 2>/dev/null
 }
+
+# Get the verifier-collapse gate mode from config.
+# Returns "warn" (default), "fail", or "off".
+#   warn -- emit stderr warning, exit code unchanged
+#   fail -- emit stderr "BLOCKED" line and exit 2 from the caller
+#   off  -- ignore the flag entirely
+get_verifier_collapse_gate_mode() {
+  local config_path="$1"
+  jq -r '.verifier_collapse.gate_mode // "warn"' "$config_path" 2>/dev/null
+}

--- a/hooks/judge-on-stop.sh
+++ b/hooks/judge-on-stop.sh
@@ -54,6 +54,28 @@ if [ -n "$SCORE" ] && [ -n "$THRESHOLD" ]; then
   fi
 fi
 
+# Verifier-collapse gate (offline heuristic; see judge-config.json
+# .verifier_collapse). gate_mode "warn" -- stderr only; "fail" --
+# exit 2 like a threshold breach; "off" -- ignore entirely.
+COLLAPSE=$(echo "$SCORECARD" | jq -r '.verifier_collapse // false' 2>/dev/null)
+if [ "$COLLAPSE" = "true" ]; then
+  GATE_MODE=$(get_verifier_collapse_gate_mode "$CONFIG_PATH")
+  REASON=$(echo "$SCORECARD" | jq -r '.dimensions.consistency.verifier_collapse_reason // "verifier collapse detected"' 2>/dev/null)
+  case "$GATE_MODE" in
+    fail)
+      echo "Verdict BLOCKED: verifier collapse detected for $SKILL_NAME — $REASON" >&2
+      echo "Tip: set judge-config.json.verifier_collapse.gate_mode to \"warn\" to demote to a warning." >&2
+      exit 2
+      ;;
+    off)
+      ;;  # silent
+    *)
+      echo "Verdict WARNING: verifier collapse detected for $SKILL_NAME — $REASON" >&2
+      echo "Tip: set judge-config.json.verifier_collapse.gate_mode to \"fail\" to block on this signal." >&2
+      ;;
+  esac
+fi
+
 # PASS: Output score as additional context
 cat <<EOF
 {

--- a/judge-config.json
+++ b/judge-config.json
@@ -44,5 +44,16 @@
     "model": "claude-haiku-4-5",
     "budget_tokens": null,
     "task_budget_tokens": null
+  },
+  "verifier_collapse": {
+    "_comment": "Detect verifier collapse over the rolling window of recent scorecards for the same skill. Flags when >= top_bucket_fraction of the last <window> composites are in the top bucket AND stdev < max_std_dev. Pure offline statistics over scores/; no LLM call. gate_mode: 'warn' (stderr only) | 'fail' (hook exit 2).",
+    "enabled": true,
+    "window": 10,
+    "min_samples": 5,
+    "top_threshold": 8.5,
+    "top_bucket_fraction": 0.95,
+    "max_std_dev": 0.3,
+    "consistency_dock": 3,
+    "gate_mode": "warn"
   }
 }

--- a/schemas/scorecard.v1.schema.json
+++ b/schemas/scorecard.v1.schema.json
@@ -124,6 +124,10 @@
       "type": "string",
       "enum": ["config", "rubric"],
       "description": "Whether the weights came from the global config or a per-rubric <rubric>.weights.json sidecar."
+    },
+    "verifier_collapse": {
+      "type": "boolean",
+      "description": "Top-level mirror of dimensions.consistency.verifier_collapse. Present only when the verifier-collapse detector ran (judge-config.json.verifier_collapse.enabled=true). True = the rolling window of recent scorecards for this skill showed flatline-at-top behaviour; see the consistency dim entry for reason and stats."
     }
   },
   "$defs": {
@@ -145,6 +149,19 @@
         "llm_justification": {
           "type": ["string", "null"],
           "description": "Justification produced by the LLM second-opinion analyzer. Present alongside llm_score."
+        },
+        "verifier_collapse": {
+          "type": "boolean",
+          "description": "Present on the consistency dim entry when the verifier-collapse detector ran. True = the rolling window of recent scorecards for this skill showed flatline-at-top behaviour, distinct from low-variance consistency."
+        },
+        "verifier_collapse_reason": {
+          "type": "string",
+          "description": "One-line human-readable explanation of why verifier_collapse=true. Empty/absent when not flagged."
+        },
+        "verifier_collapse_stats": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Numeric context for the verifier-collapse signal: rolling window size, top_bucket_fraction, observed std_dev, configured thresholds. Surfaced even on near-misses so explain output can show why a collapse was/wasn't flagged."
         }
       }
     }

--- a/skills/judge/SKILL.md
+++ b/skills/judge/SKILL.md
@@ -2,7 +2,7 @@
 name: judge
 displayName: "Verdict — Universal Quality Evaluator"
 description: "Evaluates the execution quality of any skill or agent using 7-dimension scoring with configurable rubrics"
-version: "2.0.3"
+version: "2.0.4"
 author: "Sattyam Jain"
 allowed-tools: [Read, Write, Edit, Bash]
 autoActivate:

--- a/skills/judge/rubrics/default.md
+++ b/skills/judge/rubrics/default.md
@@ -82,6 +82,25 @@ This is the default rubric applied when no domain-specific rubric is matched. It
 | 3-4   | Noticeable shifts in quality or tone. Some sections are significantly weaker than others. |
 | 1-2   | Wildly inconsistent. Output feels like it was assembled from disparate sources. |
 
+**Verifier-collapse detector (v2.0.4+, offline heuristic).** When the
+rolling window of recent scorecards for the same skill shows the
+judge has flatlined at the top of the scale, the dimension is docked
+separately from the variance-based criteria above. Specifically, when
+the fraction of recent composites in the top bucket
+(`>= top_threshold`, default 8.5) crosses
+`top_bucket_fraction` (default 0.95) **and** `std_dev` falls below
+`max_std_dev` (default 0.3) — over at least `min_samples` (default 5)
+out of the last `window` (default 10) scorecards — `verifier_collapse`
+is set to `true` and the consistency score is docked by
+`consistency_dock` (default 3). This composition prevents the
+existing low-variance branch from rewarding a collapsed verifier (it
+would otherwise grant a `+1` "highly consistent" bonus to the same
+data that triggers the dock). Pure stdlib statistics; no LLM call.
+Configurable via `judge-config.json.verifier_collapse` (set
+`enabled: false` to disable). Derived from Verdict's own consistency
+dimension plus the Soft-SVeRL project anchor — distinct from
+variance-based consistency, not a sibling analogy.
+
 ## Red Flags (Auto-Deductions)
 - Output contains hallucinated facts or fabricated references
 - Output contradicts itself within the same response

--- a/skills/judge/scripts/explain.py
+++ b/skills/judge/scripts/explain.py
@@ -125,6 +125,16 @@ def render_json(card: Dict[str, Any]) -> str:
             out_entry["llm_score"] = entry["llm_score"]
         if "llm_justification" in entry:
             out_entry["llm_justification"] = entry["llm_justification"]
+        # Surface the verifier-collapse signal from the consistency
+        # dimension into explain.v1 so PR-side consumers can act on
+        # it without re-running the detector.
+        for key in (
+            "verifier_collapse",
+            "verifier_collapse_reason",
+            "verifier_collapse_stats",
+        ):
+            if key in entry:
+                out_entry[key] = entry[key]
         dims_out.append(out_entry)
 
     adjustments_in = card.get("adjustments", {}) or {}
@@ -159,6 +169,13 @@ def render_json(card: Dict[str, Any]) -> str:
         "recommendations": list(card.get("recommendations", []) or []),
         "evidence": _evidence_block(card),
     }
+    # Mirror the top-level verifier_collapse flag (when present) so
+    # CI scripts can detect it with a single `.verifier_collapse` jq
+    # query without descending into the dimensions array. The
+    # consistency dim entry above remains the source of truth for
+    # the reason and the stats.
+    if "verifier_collapse" in card:
+        payload["verifier_collapse"] = bool(card.get("verifier_collapse"))
     return json.dumps(payload, indent=2, ensure_ascii=False)
 
 
@@ -476,6 +493,46 @@ def truncate_markdown(
     return rendered[:body_budget].rstrip() + footer
 
 
+def _md_verifier_collapse_callout(card: Dict[str, Any]) -> Optional[str]:
+    """Render a "⚠️ Verifier collapse detected" callout when flagged.
+
+    Returns ``None`` when the scorecard does not carry a flag, so the
+    caller can skip the section. The callout pulls the reason and
+    stats from the consistency dim entry (the source of truth) and
+    surfaces both the human-readable reason and the rolling-window
+    stats that drove it.
+    """
+    if not card.get("verifier_collapse"):
+        return None
+    consistency = (card.get("dimensions") or {}).get("consistency") or {}
+    reason = consistency.get("verifier_collapse_reason") or (
+        "Verifier collapse detected over the recent scorecard window "
+        "(see judge-config.json.verifier_collapse)."
+    )
+    stats = consistency.get("verifier_collapse_stats") or {}
+    lines = [
+        "## ⚠️ Verifier collapse detected",
+        "",
+        "The consistency dimension was docked because the rolling "
+        "window of recent scorecards for this skill shows the "
+        "judge/verifier has flatlined at the top of the scale — a "
+        "failure mode distinct from low score variance, derived from "
+        "Verdict's own consistency dimension plus the Soft-SVeRL "
+        "signal.",
+        "",
+        f"- **Reason:** {reason}",
+    ]
+    if stats:
+        lines.append(
+            f"- **Stats:** window n={stats.get('window', '?')}, "
+            f"top_bucket_fraction={stats.get('top_bucket_fraction', '?')} "
+            f"(threshold {stats.get('max_std_dev', '?')} for std_dev, "
+            f"actual {stats.get('std_dev', '?')}; "
+            f"top_threshold={stats.get('top_threshold', '?')})"
+        )
+    return "\n".join(lines)
+
+
 def render_markdown(card: Dict[str, Any]) -> str:
     """Render a PR-comment-friendly Markdown explanation."""
     skill = card.get("skill", "?")
@@ -501,8 +558,14 @@ def render_markdown(card: Dict[str, Any]) -> str:
         header += f"\n\n_{summary}_"
 
     entries = _ordered_dimension_entries(card)
-    sections: List[str] = [header, "## Per-dimension breakdown",
-                           _md_dimension_table(entries)]
+    sections: List[str] = [header]
+    callout = _md_verifier_collapse_callout(card)
+    if callout:
+        sections.append(callout)
+    sections.extend([
+        "## Per-dimension breakdown",
+        _md_dimension_table(entries),
+    ])
 
     overlay = _md_llm_overlay(entries)
     if overlay:

--- a/skills/judge/scripts/score.py
+++ b/skills/judge/scripts/score.py
@@ -517,6 +517,7 @@ def analyze_dimension(
     history: List[Dict[str, Any]],
     tokenizer_baseline: float = 1.0,
     duration_ms_dock_threshold: Optional[int] = None,
+    verifier_collapse_config: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Score a single dimension (1-10) with justification.
 
@@ -526,6 +527,9 @@ def analyze_dimension(
     ``duration_ms_dock_threshold`` (default ``None`` = report-only) is
     also forwarded to the efficiency analyser; see
     :func:`_analyze_efficiency`.
+    ``verifier_collapse_config`` (default ``None`` = disabled) is
+    forwarded to the consistency analyser; see
+    :func:`_detect_verifier_collapse`.
     """
     total_lines = len(transcript_lines)
     full_text = "\n".join(transcript_lines)
@@ -546,7 +550,7 @@ def analyze_dimension(
     elif name == "safety":
         return _analyze_safety(transcript_lines)
     elif name == "consistency":
-        return _analyze_consistency(history)
+        return _analyze_consistency(history, verifier_collapse_config)
     else:
         return {"score": 5, "justification": f"Unknown dimension: {name}"}
 
@@ -1005,27 +1009,162 @@ def _analyze_safety(lines: List[str]) -> Dict[str, Any]:
     return {"score": score, "justification": justification}
 
 
-def _analyze_consistency(history: List[Dict[str, Any]]) -> Dict[str, Any]:
+def _detect_verifier_collapse(
+    history: List[Dict[str, Any]],
+    vc_config: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Detect verifier collapse over a rolling window of recent scorecards.
+
+    Verifier collapse is the failure mode where a judge has flatlined at
+    the top of the scale — most recent scores fall in the top bucket
+    AND variance is near zero. This is distinct from "low variance" as
+    scored by :func:`_analyze_consistency`, which would otherwise
+    *reward* the failure mode with a low-std_dev bonus. The detector
+    here composes with that logic by adding an explicit dock when both
+    criteria hit, derived from Verdict's own consistency dimension plus
+    the project-anchor "Soft-SVeRL" signal.
+
+    Returns a dict with::
+
+        {
+            "flagged": bool,
+            "reason": str,           # short, one-line; empty when not flagged
+            "stats": {
+                "window": int,            # actual window evaluated
+                "min_samples": int,       # threshold for "enough signal"
+                "top_threshold": float,
+                "top_bucket_fraction": float,   # observed fraction in top bucket
+                "max_std_dev": float,
+                "std_dev": float,             # observed std dev over window
+            },
+        }
+
+    When ``vc_config`` is ``None`` or has ``enabled=False`` the detector
+    short-circuits with ``flagged=False`` and an empty reason. Pure
+    stdlib statistics — no LLM call.
+    """
+    if not vc_config or not vc_config.get("enabled", False):
+        return {"flagged": False, "reason": "", "stats": {}}
+
+    try:
+        window = int(vc_config.get("window", 10))
+        min_samples = int(vc_config.get("min_samples", 5))
+        top_threshold = float(vc_config.get("top_threshold", 8.5))
+        bucket_fraction = float(vc_config.get("top_bucket_fraction", 0.95))
+        max_std_dev = float(vc_config.get("max_std_dev", 0.3))
+    except (TypeError, ValueError):
+        # Malformed config: skip rather than crash the score path.
+        return {"flagged": False, "reason": "", "stats": {}}
+
+    composites = [
+        float(h["composite_score"])
+        for h in history
+        if isinstance(h, dict) and isinstance(h.get("composite_score"), (int, float))
+    ]
+    if not composites:
+        return {"flagged": False, "reason": "", "stats": {}}
+
+    # Rolling window: last <window> entries (oldest-first history, so
+    # take the tail).
+    sample = composites[-window:]
+    n = len(sample)
+    if n < min_samples:
+        return {
+            "flagged": False,
+            "reason": "",
+            "stats": {
+                "window": n,
+                "min_samples": min_samples,
+                "top_threshold": top_threshold,
+                "top_bucket_fraction": 0.0,
+                "max_std_dev": max_std_dev,
+                "std_dev": 0.0,
+            },
+        }
+
+    top_hits = sum(1 for c in sample if c >= top_threshold)
+    observed_fraction = top_hits / n
+    avg = sum(sample) / n
+    variance = sum((c - avg) ** 2 for c in sample) / n
+    std_dev = variance ** 0.5
+
+    flagged = (
+        observed_fraction >= bucket_fraction
+        and std_dev < max_std_dev
+    )
+
+    reason = ""
+    if flagged:
+        reason = (
+            f"verifier collapse: {top_hits}/{n} of recent composites "
+            f">= {top_threshold:.1f} (fraction {observed_fraction:.2f} "
+            f">= {bucket_fraction:.2f}) and std_dev {std_dev:.2f} "
+            f"< {max_std_dev:.2f}"
+        )
+
+    return {
+        "flagged": flagged,
+        "reason": reason,
+        "stats": {
+            "window": n,
+            "min_samples": min_samples,
+            "top_threshold": top_threshold,
+            "top_bucket_fraction": round(observed_fraction, 4),
+            "max_std_dev": max_std_dev,
+            "std_dev": round(std_dev, 4),
+        },
+    }
+
+
+def _analyze_consistency(
+    history: List[Dict[str, Any]],
+    verifier_collapse_config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """Consistency: compare to historical scores.
 
     Returns a neutral 5 (mid-range, non-inflating) when no prior history
     exists rather than the previous 7, which biased first-run composites
     upward. See DEEP_ANALYSIS §12.3.
+
+    When ``verifier_collapse_config`` is provided **and** has
+    ``enabled: True``, the verifier-collapse detector runs after the
+    variance-based score is computed. If collapse is detected, the
+    dimension is docked by ``consistency_dock`` (default 3 from
+    ``judge-config.json.verifier_collapse``), the dock cancelling the
+    existing "+1 highly-consistent" bonus path — without this
+    composition, a collapsed verifier would otherwise be *rewarded* by
+    the low-variance branch. When the detector runs the returned dict
+    gains ``verifier_collapse`` (bool) and, on a hit,
+    ``verifier_collapse_reason`` / ``verifier_collapse_stats``. When
+    the detector is disabled or the config is absent the key is
+    omitted entirely so CI consumers can distinguish "ran and saw
+    nothing" from "did not run".
     """
+    vc_enabled = bool(
+        verifier_collapse_config
+        and verifier_collapse_config.get("enabled")
+    )
+
     if not history:
-        return {
+        result: Dict[str, Any] = {
             "score": 5,
             "justification": "No prior history for comparison (neutral score)",
         }
+        if vc_enabled:
+            result["verifier_collapse"] = False
+        return result
 
     past_composites = [
         h.get("composite_score", 5.0) for h in history if "composite_score" in h
     ]
     if not past_composites:
-        return {
+        result = {
             "score": 5,
             "justification": "No comparable historical composites found",
         }
+        if vc_enabled:
+            result["verifier_collapse"] = False
+        return result
 
     avg = sum(past_composites) / len(past_composites)
     latest = past_composites[-1] if past_composites else avg
@@ -1054,8 +1193,33 @@ def _analyze_consistency(history: List[Dict[str, Any]]) -> Dict[str, Any]:
         f"n={len(past_composites)}"
     )
 
+    result = {}
+    if vc_enabled:
+        # Verifier-collapse detector. Composes with the variance
+        # reasoning above so a collapsed verifier nets to a dock
+        # rather than the +1 low-std_dev bonus.
+        collapse = _detect_verifier_collapse(history, verifier_collapse_config)
+        result["verifier_collapse"] = collapse["flagged"]
+        if collapse["flagged"]:
+            try:
+                dock = int(
+                    (verifier_collapse_config or {}).get("consistency_dock", 3)
+                )
+            except (TypeError, ValueError):
+                dock = 3
+            score -= dock
+            reasons.append(collapse["reason"])
+            result["verifier_collapse_reason"] = collapse["reason"]
+            result["verifier_collapse_stats"] = collapse["stats"]
+        elif collapse["stats"]:
+            # Surface stats even when not flagged so explain.py can
+            # show the near-miss context without a separate path.
+            result["verifier_collapse_stats"] = collapse["stats"]
+
     score = max(1, min(10, score))
-    return {"score": score, "justification": "; ".join(reasons)}
+    result["score"] = score
+    result["justification"] = "; ".join(reasons)
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -1454,12 +1618,20 @@ def build_scorecard(
         except (TypeError, ValueError):
             duration_ms_dock_threshold = None
 
+    # Verifier-collapse detector block (off by default; opt-in via
+    # judge-config.json.verifier_collapse.enabled). Pure stdlib stats
+    # over the rolling window of recent scorecards for this skill.
+    verifier_collapse_cfg = (
+        config.get("verifier_collapse") if isinstance(config, dict) else None
+    )
+
     # 2. Score each dimension
     dimensions: Dict[str, Dict[str, Any]] = {}
     for dim in weights:
         result = analyze_dimension(
             dim, transcript_lines, rubric_criteria, history, tokenizer_baseline,
             duration_ms_dock_threshold=duration_ms_dock_threshold,
+            verifier_collapse_config=verifier_collapse_cfg,
         )
         weight = weights[dim]
         weighted = round(result["score"] * weight, 2)
@@ -1473,6 +1645,16 @@ def build_scorecard(
         # ``tool_durations_ms`` from Claude Code v2.1.119 PostToolUse).
         if "tool_durations_ms" in result:
             dimensions[dim]["tool_durations_ms"] = result["tool_durations_ms"]
+        # Forward verifier-collapse extras from the consistency
+        # analyser so explain.py and the ship-gate can surface them
+        # without re-running the detector.
+        for key in (
+            "verifier_collapse",
+            "verifier_collapse_reason",
+            "verifier_collapse_stats",
+        ):
+            if key in result:
+                dimensions[dim][key] = result[key]
 
     # 2b. Opt-in LLM second opinion (off by default; see
     # analyzers/llm_judge.py). Mutates `dimensions` in place to add
@@ -1540,6 +1722,15 @@ def build_scorecard(
         "tokenizer_baseline": tokenizer_baseline,
         "weights_source": weights_source,
     }
+
+    # Mirror the consistency-dim verifier_collapse flag at the top
+    # level so CI scripts can grep one place (the dim entry remains
+    # the source of truth for the reason and the stats).
+    consistency_dim = dimensions.get("consistency", {}) or {}
+    if consistency_dim.get("verifier_collapse"):
+        scorecard["verifier_collapse"] = True
+    elif "verifier_collapse" in consistency_dim:
+        scorecard["verifier_collapse"] = False
 
     # 5. Persist
     saved_path = save_score(scorecard, scores_dir)

--- a/tests/test_verifier_collapse.py
+++ b/tests/test_verifier_collapse.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+"""Tests for the verifier-collapse detector (v2.0.4).
+
+Covers:
+
+1. ``_detect_verifier_collapse`` short-circuits when config is missing
+   or ``enabled=false``; no false positives below ``min_samples``;
+   fires on a flatlined-top window; does NOT fire when variance
+   exceeds ``max_std_dev``.
+2. ``_analyze_consistency`` composes the dock with the existing
+   variance-based reasoning so a collapsed verifier nets to a dock
+   rather than the prior +1 low-variance bonus, and the returned dict
+   carries ``verifier_collapse`` / ``verifier_collapse_reason`` /
+   ``verifier_collapse_stats``.
+3. ``build_scorecard`` end-to-end produces a scorecard with the
+   top-level ``verifier_collapse`` mirror.
+4. ``explain.v1`` JSON renders the top-level flag + the per-dim
+   reason + stats; Markdown renders the ``⚠️ Verifier collapse
+   detected`` callout, anchored on the Soft-SVeRL project anchor
+   (no sibling benchmarks named).
+5. ``hooks/judge-on-stop.sh`` honours ``gate_mode``:
+   ``warn`` -> exit 0 + stderr warning; ``fail`` -> exit 2 + stderr
+   BLOCKED line; ``off`` -> exit 0 + silent.
+
+Stdlib-only; no third-party deps.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = PROJECT_ROOT / "skills" / "judge" / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import score  # noqa: E402  -- must follow sys.path manipulation
+import explain  # noqa: E402  -- must follow sys.path manipulation
+
+
+_DEFAULT_CFG: Dict[str, Any] = {
+    "enabled": True,
+    "window": 10,
+    "min_samples": 5,
+    "top_threshold": 8.5,
+    "top_bucket_fraction": 0.95,
+    "max_std_dev": 0.3,
+    "consistency_dock": 3,
+}
+
+
+def _hist(composites: List[float]) -> List[Dict[str, Any]]:
+    """Build a synthetic history of scorecards with the given composites."""
+    return [{"composite_score": c} for c in composites]
+
+
+# ---------------------------------------------------------------------------
+# Pure detector
+# ---------------------------------------------------------------------------
+
+
+class TestDetectorGuards(unittest.TestCase):
+    def test_none_config_short_circuits(self) -> None:
+        r = score._detect_verifier_collapse(_hist([9.5] * 10), None)
+        self.assertFalse(r["flagged"])
+        self.assertEqual(r["stats"], {})
+
+    def test_disabled_config_short_circuits(self) -> None:
+        cfg = {**_DEFAULT_CFG, "enabled": False}
+        r = score._detect_verifier_collapse(_hist([9.5] * 10), cfg)
+        self.assertFalse(r["flagged"])
+
+    def test_empty_history_no_flag(self) -> None:
+        r = score._detect_verifier_collapse([], _DEFAULT_CFG)
+        self.assertFalse(r["flagged"])
+
+    def test_below_min_samples_no_flag(self) -> None:
+        r = score._detect_verifier_collapse(
+            _hist([9.5, 9.5, 9.5]), _DEFAULT_CFG
+        )
+        self.assertFalse(r["flagged"])
+        # Stats still reported so callers can see the window size.
+        self.assertEqual(r["stats"]["window"], 3)
+        self.assertEqual(r["stats"]["min_samples"], 5)
+
+
+class TestDetectorPositive(unittest.TestCase):
+    def test_flatlined_top_window_flags(self) -> None:
+        r = score._detect_verifier_collapse(_hist([9.5] * 10), _DEFAULT_CFG)
+        self.assertTrue(r["flagged"])
+        self.assertIn("verifier collapse", r["reason"])
+        self.assertGreaterEqual(r["stats"]["top_bucket_fraction"], 0.95)
+        self.assertLess(r["stats"]["std_dev"], 0.3)
+
+    def test_uses_rolling_window_tail(self) -> None:
+        # Old varied history followed by 10 collapsed cards: window=10
+        # should look at the tail and flag.
+        composites = [6.0, 7.0, 8.0, 5.5, 7.2] + [9.5] * 10
+        r = score._detect_verifier_collapse(_hist(composites), _DEFAULT_CFG)
+        self.assertTrue(r["flagged"])
+
+    def test_custom_threshold_respected(self) -> None:
+        cfg = {**_DEFAULT_CFG, "top_threshold": 9.8}
+        # All 9.5 -- below the bumped top_threshold of 9.8.
+        r = score._detect_verifier_collapse(_hist([9.5] * 10), cfg)
+        self.assertFalse(r["flagged"])
+
+
+class TestDetectorNegative(unittest.TestCase):
+    def test_variance_hides_collapse(self) -> None:
+        # Alternating 9.5 / 8.0 -- top fraction stays high but std_dev
+        # exceeds 0.3.
+        composites = [9.5 if i % 2 else 8.0 for i in range(10)]
+        r = score._detect_verifier_collapse(_hist(composites), _DEFAULT_CFG)
+        self.assertFalse(r["flagged"])
+        self.assertGreater(r["stats"]["std_dev"], 0.3)
+
+    def test_below_top_threshold_no_flag(self) -> None:
+        # All composites are 8.0 -- below top_threshold of 8.5.
+        r = score._detect_verifier_collapse(_hist([8.0] * 10), _DEFAULT_CFG)
+        self.assertFalse(r["flagged"])
+
+    def test_malformed_config_silently_skips(self) -> None:
+        cfg = {"enabled": True, "window": "ten"}  # non-numeric
+        r = score._detect_verifier_collapse(_hist([9.5] * 10), cfg)
+        self.assertFalse(r["flagged"])
+
+    def test_non_dict_history_entries_ignored(self) -> None:
+        # Past _analyze_consistency calls survived corrupt entries; the
+        # detector must too.
+        history = [
+            {"composite_score": 9.5},
+            "garbage",
+            None,
+            {"composite_score": 9.5},
+            {"composite_score": "not a number"},
+        ]
+        r = score._detect_verifier_collapse(history, _DEFAULT_CFG)
+        # Only 2 valid samples -> below min_samples, not flagged.
+        self.assertFalse(r["flagged"])
+
+
+# ---------------------------------------------------------------------------
+# Consistency analyzer composition
+# ---------------------------------------------------------------------------
+
+
+class TestConsistencyComposition(unittest.TestCase):
+    def test_collapsed_history_docks_and_flags(self) -> None:
+        # All 9.5s -- existing logic would award base 8 + 1 (low-std)
+        # = 9. With dock 3 -> 6.
+        r = score._analyze_consistency(_hist([9.5] * 10), _DEFAULT_CFG)
+        self.assertTrue(r["verifier_collapse"])
+        self.assertEqual(r["score"], 6)
+        self.assertIn("verifier collapse", r["justification"])
+        self.assertIn("verifier_collapse_reason", r)
+        self.assertIn("verifier_collapse_stats", r)
+
+    def test_varied_history_no_flag_no_dock(self) -> None:
+        # Spread 6.0 - 8.5 -- std_dev ~ 0.8+. Not collapsed.
+        composites = [6.0, 6.5, 7.0, 7.2, 7.5, 8.0, 8.3, 8.5]
+        r = score._analyze_consistency(_hist(composites), _DEFAULT_CFG)
+        self.assertFalse(r["verifier_collapse"])
+        # Score should be reasonable (not docked by collapse).
+        self.assertGreaterEqual(r["score"], 6)
+
+    def test_no_history_neutral_no_flag(self) -> None:
+        r = score._analyze_consistency([], _DEFAULT_CFG)
+        self.assertEqual(r["score"], 5)
+        self.assertFalse(r["verifier_collapse"])
+
+    def test_disabled_config_acts_like_pre_v204(self) -> None:
+        # All 9.5s with detector disabled -> existing low-std bonus
+        # kicks in, score lands at 9, and the verifier_collapse key
+        # is OMITTED entirely (so CI can tell "did not run" from
+        # "ran and saw nothing").
+        cfg = {**_DEFAULT_CFG, "enabled": False}
+        r = score._analyze_consistency(_hist([9.5] * 10), cfg)
+        self.assertNotIn("verifier_collapse", r)
+        self.assertEqual(r["score"], 9)
+
+    def test_custom_dock_respected(self) -> None:
+        cfg = {**_DEFAULT_CFG, "consistency_dock": 5}
+        r = score._analyze_consistency(_hist([9.5] * 10), cfg)
+        # base 8 + 1 (low-std) - 5 (dock) = 4
+        self.assertEqual(r["score"], 4)
+        self.assertTrue(r["verifier_collapse"])
+
+
+# ---------------------------------------------------------------------------
+# build_scorecard end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestScorecardTopLevelMirror(unittest.TestCase):
+    """Drive build_scorecard against a pre-populated scores dir."""
+
+    def _make_history(self, scores_dir: Path, skill: str) -> None:
+        """Write 10 high-composite scorecards for *skill* into *scores_dir*."""
+        scores_dir.mkdir(parents=True, exist_ok=True)
+        for i in range(10):
+            ts = f"2026-05-2{i % 9}T0{i}-00-00Z"
+            (scores_dir / f"{skill}_{ts}.json").write_text(
+                json.dumps(
+                    {
+                        "skill": skill,
+                        "timestamp": ts,
+                        "composite_score": 9.5,
+                        "grade": "A",
+                        "dimensions": {},
+                    }
+                )
+            )
+
+    def _make_transcript(self, path: Path) -> None:
+        path.write_text(
+            '{"role":"user","content":"hi"}\n'
+            '{"role":"assistant","content":"hello"}\n'
+        )
+
+    def _make_config(self, path: Path, enabled: bool) -> None:
+        path.write_text(
+            json.dumps(
+                {
+                    "auto_judge": {"enabled": True, "always": [], "never": []},
+                    "scoring": {
+                        "dimensions": {
+                            "correctness": 0.25,
+                            "completeness": 0.20,
+                            "adherence": 0.15,
+                            "actionability": 0.15,
+                            "efficiency": 0.10,
+                            "safety": 0.10,
+                            "consistency": 0.05,
+                        }
+                    },
+                    "verifier_collapse": {**_DEFAULT_CFG, "enabled": enabled},
+                }
+            )
+        )
+
+    def test_flag_mirrored_to_top_level_when_collapsed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            scores_dir = tmp_path / "scores"
+            self._make_history(scores_dir, "code-review")
+            transcript = tmp_path / "t.jsonl"
+            self._make_transcript(transcript)
+            cfg = tmp_path / "judge-config.json"
+            self._make_config(cfg, enabled=True)
+
+            card = score.build_scorecard(
+                skill_name="code-review",
+                transcript_path=str(transcript),
+                rubric_dir=str(PROJECT_ROOT / "skills" / "judge" / "rubrics"),
+                scores_dir=str(scores_dir),
+                config_path=str(cfg),
+            )
+            self.assertTrue(card.get("verifier_collapse"))
+            consistency = card["dimensions"]["consistency"]
+            self.assertTrue(consistency["verifier_collapse"])
+            self.assertIn("verifier_collapse_reason", consistency)
+            self.assertIn("verifier_collapse_stats", consistency)
+
+    def test_flag_false_when_detector_runs_but_no_collapse(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            scores_dir = tmp_path / "scores"
+            scores_dir.mkdir(parents=True, exist_ok=True)
+            # Varied history -> detector runs but does not flag.
+            for i, composite in enumerate([5.0, 6.5, 7.0, 8.0, 6.5, 7.5, 8.0, 7.0]):
+                ts = f"2026-05-2{i % 9}T0{i}-00-00Z"
+                (scores_dir / f"code-review_{ts}.json").write_text(
+                    json.dumps(
+                        {
+                            "skill": "code-review",
+                            "timestamp": ts,
+                            "composite_score": composite,
+                            "grade": "B",
+                            "dimensions": {},
+                        }
+                    )
+                )
+            transcript = tmp_path / "t.jsonl"
+            self._make_transcript(transcript)
+            cfg = tmp_path / "judge-config.json"
+            self._make_config(cfg, enabled=True)
+
+            card = score.build_scorecard(
+                skill_name="code-review",
+                transcript_path=str(transcript),
+                rubric_dir=str(PROJECT_ROOT / "skills" / "judge" / "rubrics"),
+                scores_dir=str(scores_dir),
+                config_path=str(cfg),
+            )
+            self.assertFalse(card.get("verifier_collapse", True))
+            self.assertFalse(
+                card["dimensions"]["consistency"]["verifier_collapse"]
+            )
+
+    def test_no_field_when_detector_disabled(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            scores_dir = tmp_path / "scores"
+            self._make_history(scores_dir, "code-review")
+            transcript = tmp_path / "t.jsonl"
+            self._make_transcript(transcript)
+            cfg = tmp_path / "judge-config.json"
+            self._make_config(cfg, enabled=False)
+
+            card = score.build_scorecard(
+                skill_name="code-review",
+                transcript_path=str(transcript),
+                rubric_dir=str(PROJECT_ROOT / "skills" / "judge" / "rubrics"),
+                scores_dir=str(scores_dir),
+                config_path=str(cfg),
+            )
+            # Detector disabled => the field is omitted entirely at
+            # both top level and the consistency dim, so CI consumers
+            # can tell "did not run" apart from "ran and saw nothing".
+            self.assertNotIn("verifier_collapse", card)
+            consistency = card["dimensions"]["consistency"]
+            self.assertNotIn("verifier_collapse", consistency)
+
+
+# ---------------------------------------------------------------------------
+# explain.v1
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_collapsed_card() -> Dict[str, Any]:
+    return {
+        "skill": "code-review",
+        "composite_score": 8.7,
+        "grade": "A-",
+        "grade_label": "Very Good",
+        "rubric_used": "code-review",
+        "model": "claude-opus-4-7",
+        "timestamp": "2026-05-29T12:00:00Z",
+        "summary": "OK.",
+        "one_liner": "Solid execution.",
+        "verifier_collapse": True,
+        "dimensions": {
+            "correctness": {
+                "score": 9,
+                "weight": 0.25,
+                "weighted": 2.25,
+                "justification": "clean",
+            },
+            "consistency": {
+                "score": 6,
+                "weight": 0.05,
+                "weighted": 0.3,
+                "justification": "collapsed",
+                "verifier_collapse": True,
+                "verifier_collapse_reason": "verifier collapse: 10/10 of recent composites >= 8.5 (fraction 1.00 >= 0.95) and std_dev 0.10 < 0.30",
+                "verifier_collapse_stats": {
+                    "window": 10,
+                    "top_bucket_fraction": 1.0,
+                    "std_dev": 0.10,
+                    "max_std_dev": 0.3,
+                    "top_threshold": 8.5,
+                },
+            },
+        },
+        "red_flags": [],
+        "bonuses": [],
+        "critical_issues": [],
+        "recommendations": [],
+        "adjustments": {"deduction": 0.0, "bonus": 0.0},
+        "transcript_lines": 100,
+    }
+
+
+class TestExplainJsonV1(unittest.TestCase):
+    def test_top_level_verifier_collapse_emitted(self) -> None:
+        card = _synthetic_collapsed_card()
+        payload = json.loads(explain.render_json(card))
+        self.assertTrue(payload.get("verifier_collapse"))
+
+    def test_per_dim_reason_and_stats_surfaced(self) -> None:
+        card = _synthetic_collapsed_card()
+        payload = json.loads(explain.render_json(card))
+        consistency = next(
+            d for d in payload["dimensions"] if d["name"] == "consistency"
+        )
+        self.assertTrue(consistency["verifier_collapse"])
+        self.assertIn("verifier_collapse_reason", consistency)
+        self.assertIn("verifier_collapse_stats", consistency)
+
+    def test_field_omitted_when_no_collapse(self) -> None:
+        card = _synthetic_collapsed_card()
+        del card["verifier_collapse"]
+        card["dimensions"]["consistency"]["verifier_collapse"] = False
+        del card["dimensions"]["consistency"]["verifier_collapse_reason"]
+        del card["dimensions"]["consistency"]["verifier_collapse_stats"]
+        payload = json.loads(explain.render_json(card))
+        self.assertNotIn("verifier_collapse", payload)
+
+    def test_format_version_unchanged(self) -> None:
+        card = _synthetic_collapsed_card()
+        payload = json.loads(explain.render_json(card))
+        self.assertEqual(payload["format_version"], "explain.v1")
+
+
+class TestExplainMarkdown(unittest.TestCase):
+    def test_callout_emitted_when_flagged(self) -> None:
+        md = explain.render_markdown(_synthetic_collapsed_card())
+        self.assertIn("⚠️ Verifier collapse detected", md)
+        self.assertIn("Soft-SVeRL", md)
+        self.assertIn("window n=10", md)
+
+    def test_no_callout_when_not_flagged(self) -> None:
+        card = _synthetic_collapsed_card()
+        del card["verifier_collapse"]
+        card["dimensions"]["consistency"]["verifier_collapse"] = False
+        md = explain.render_markdown(card)
+        self.assertNotIn("Verifier collapse detected", md)
+
+    def test_no_sibling_benchmark_named(self) -> None:
+        """G13 anti-cross-pollination: no SWE-bench, MMLU, GSM8K, etc."""
+        md = explain.render_markdown(_synthetic_collapsed_card())
+        forbidden = ("SWE-bench", "MMLU", "GSM8K", "BIG-bench", "HumanEval")
+        for token in forbidden:
+            self.assertNotIn(token, md, f"forbidden sibling-bench '{token}' leaked into Markdown")
+
+
+# ---------------------------------------------------------------------------
+# Hook ship-gate
+# ---------------------------------------------------------------------------
+
+
+class TestHookGateMode(unittest.TestCase):
+    """End-to-end test of judge-on-stop.sh gate_mode behaviour.
+
+    We stage a temp PLUGIN_ROOT mirroring the real layout, then drive
+    the hook from a pre-populated scores dir so the actual score.py
+    invocation produces a verifier_collapse=true scorecard. This
+    exercises both the hook plumbing and the verifier_collapse plumbing
+    in one shot.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not shutil.which("jq") or not shutil.which("bc"):
+            raise unittest.SkipTest("jq + bc required for hook tests")
+
+    def _stage(self, tmp: Path, gate_mode: str) -> Tuple[Path, Path]:
+        """Build a temp PLUGIN_ROOT; return (plugin_root, transcript_path)."""
+        plugin = tmp / "plugin"
+        (plugin / "hooks").mkdir(parents=True)
+        (plugin / "skills" / "judge" / "scripts").mkdir(parents=True)
+        (plugin / "skills" / "judge" / "rubrics").mkdir(parents=True)
+        (plugin / "skills" / "judge" / "scores").mkdir(parents=True)
+
+        # Copy the real hook + common + score machinery.
+        shutil.copy(
+            PROJECT_ROOT / "hooks" / "common.sh",
+            plugin / "hooks" / "common.sh",
+        )
+        shutil.copy(
+            PROJECT_ROOT / "hooks" / "judge-on-stop.sh",
+            plugin / "hooks" / "judge-on-stop.sh",
+        )
+        (plugin / "hooks" / "judge-on-stop.sh").chmod(0o755)
+        # The scoring engine and rubric set must be the actual ones --
+        # symlink to avoid copying ~1.5 MB of rubrics.
+        (plugin / "skills" / "judge" / "scripts").rmdir()
+        (plugin / "skills" / "judge" / "scripts").symlink_to(
+            PROJECT_ROOT / "skills" / "judge" / "scripts"
+        )
+        # ditto rubrics + analyzers + adapters (the scripts need them
+        # via sys.path at runtime).
+        (plugin / "skills" / "judge" / "rubrics").rmdir()
+        (plugin / "skills" / "judge" / "rubrics").symlink_to(
+            PROJECT_ROOT / "skills" / "judge" / "rubrics"
+        )
+        (plugin / "skills" / "judge" / "analyzers").symlink_to(
+            PROJECT_ROOT / "skills" / "judge" / "analyzers"
+        )
+        (plugin / "skills" / "judge" / "adapters").symlink_to(
+            PROJECT_ROOT / "skills" / "judge" / "adapters"
+        )
+
+        # Pre-populate scores/ with 10 high-composite cards so the
+        # detector flags collapse.
+        scores = plugin / "skills" / "judge" / "scores"
+        for i in range(10):
+            ts = f"2026-05-2{i % 9}T0{i}-00-00Z"
+            (scores / f"code-review_{ts}.json").write_text(
+                json.dumps(
+                    {
+                        "skill": "code-review",
+                        "timestamp": ts,
+                        "composite_score": 9.5,
+                        "grade": "A",
+                        "dimensions": {},
+                    }
+                )
+            )
+
+        # auto_judge.always includes code-review so should_auto_judge
+        # returns true; threshold is low enough that we do not trip
+        # the existing exit-2 gate (we want the collapse gate to fire,
+        # not the threshold gate).
+        (plugin / "judge-config.json").write_text(
+            json.dumps(
+                {
+                    "auto_judge": {
+                        "enabled": True,
+                        "always": ["code-review"],
+                        "never": [],
+                        "threshold": 0.0,
+                    },
+                    "scoring": {
+                        "dimensions": {
+                            "correctness": 0.25,
+                            "completeness": 0.20,
+                            "adherence": 0.15,
+                            "actionability": 0.15,
+                            "efficiency": 0.10,
+                            "safety": 0.10,
+                            "consistency": 0.05,
+                        }
+                    },
+                    "verifier_collapse": {**_DEFAULT_CFG, "gate_mode": gate_mode},
+                }
+            )
+        )
+
+        # Transcript with a skill marker the hook's detect_skill
+        # patterns will pick up. The "skill" JSON field is the most
+        # robust pattern (works for stdin-style hook payloads).
+        transcript = tmp / "transcript.jsonl"
+        transcript.write_text(
+            '{"role":"user","content":"reviewing","skill":"code-review"}\n'
+            '{"role":"assistant","content":"ok"}\n'
+        )
+        return plugin, transcript
+
+    def _run_hook(self, plugin: Path, transcript: Path) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["bash", str(plugin / "hooks" / "judge-on-stop.sh")],
+            input=json.dumps({"transcript_path": str(transcript)}),
+            capture_output=True,
+            text=True,
+        )
+
+    def test_gate_mode_warn_exits_0_with_stderr_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin, transcript = self._stage(Path(tmp), gate_mode="warn")
+            result = self._run_hook(plugin, transcript)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("Verdict WARNING: verifier collapse", result.stderr)
+
+    def test_gate_mode_fail_exits_2_with_stderr_blocked(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin, transcript = self._stage(Path(tmp), gate_mode="fail")
+            result = self._run_hook(plugin, transcript)
+            self.assertEqual(result.returncode, 2, result.stderr)
+            self.assertIn("Verdict BLOCKED: verifier collapse", result.stderr)
+
+    def test_gate_mode_off_silent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin, transcript = self._stage(Path(tmp), gate_mode="off")
+            result = self._run_hook(plugin, transcript)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertNotIn("verifier collapse", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a **stdlib-only, default-on** verifier-collapse detector to the
consistency dimension and wires the resulting flag into both
`/judge --explain` (Markdown + `explain.v1` JSON) and the
`hooks/judge-on-stop.sh` ship-gate.

The signal is **derived from Verdict's own consistency dimension plus
the Soft-SVeRL project anchor** — G13 anti-cross-pollination
preserved (no sibling-benchmark analogies anywhere in code, docs,
or tests; the test suite asserts that constraint).

## Bug being closed

`_analyze_consistency` (`score.py:1037`) already awards a `+1` *"highly
consistent"* bonus whenever `std_dev <= 0.8`. That branch silently
*rewards* the failure mode where a judge has flatlined at the top of
the scale — a collapsed verifier picks up the bonus instead of a dock.

The new detector composes with that branch so a collapse nets to a
dock instead. Without composition, the bug stays silent.

## Detector

Over the rolling window of recent scorecards for the same skill, flag
`verifier_collapse=true` when **both**:

| Condition | Default |
|-----------|---------|
| fraction of composites `>= top_threshold` exceeds `top_bucket_fraction` | `>= 8.5` for `>= 0.95` |
| `std_dev` of those composites `< max_std_dev` | `< 0.3` (tighter than the existing `0.8` "highly consistent" cutoff) |
| at least `min_samples` of the last `<window>` cards available | `5 of 10` |

On a hit: dock by `consistency_dock` (default `3`) and append a
one-line reason. Pure stdlib statistics; no LLM call.

## What's added

### Scorecard
- `dimensions.consistency.verifier_collapse` (bool, when detector ran)
- `dimensions.consistency.verifier_collapse_reason` (when flagged)
- `dimensions.consistency.verifier_collapse_stats` (window stats)
- top-level `verifier_collapse` mirror (when detector ran)

Field absent at both levels when `judge-config.json.verifier_collapse.enabled = false`, so CI consumers can distinguish *"did not run"* from *"ran and saw nothing"*.

### Config (`judge-config.json.verifier_collapse`)
Enabled by default. Knobs: `window`, `min_samples`, `top_threshold`,
`top_bucket_fraction`, `max_std_dev`, `consistency_dock`, `gate_mode`.

### `/judge --explain`
- **JSON (`explain.v1`)** — top-level + per-dim fields surfaced; `format_version` unchanged (additive).
- **Markdown** — `⚠️ Verifier collapse detected` callout above the dimension table, anchored on Verdict's own consistency dim + Soft-SVeRL.

### Ship-gate (`hooks/judge-on-stop.sh`)
Honours `judge-config.json.verifier_collapse.gate_mode`:
- `warn` (default) → stderr `Verdict WARNING: verifier collapse detected for $SKILL_NAME — $REASON`, exit unchanged
- `fail` → stderr `Verdict BLOCKED: …` + `exit 2` (same shape as the existing threshold-breach gate)
- `off` → silent

### Schema
`schemas/scorecard.v1.schema.json` declares the new optional fields. Backward-compatible additive extension; no required-field change.

### Rubric
`skills/judge/rubrics/default.md` Consistency section grows a v2.0.4+ paragraph explaining the composition. The v4.3 rubric inventory stays pinned at 11.

## Test plan

```shell
python3 -m unittest discover tests/ -v               # 591/591 pass
python3 -m unittest tests.test_verifier_collapse -v  # 29 new tests
shellcheck hooks/judge-on-stop.sh hooks/common.sh    # clean
python3 skills/judge/scripts/hook_lint.py hooks/judge-on-stop.sh
python3 skills/judge/scripts/hook_lint.py hooks/common.sh
python3 scripts/bench_lint.py --quiet                # corpus still clean
python3 scripts/check_readme_release_anchor.py       # README anchor matches CHANGELOG
```

29 new tests cover:
- detector guards (None config / disabled / empty / below min_samples / malformed / non-dict entries)
- positive cases (flatlined window flags; rolling-window tail; custom thresholds)
- negative cases (variance hides; below top_threshold; bad config silently skipped)
- consistency composition (collapsed → dock + flag, base 8 + 1 low-std bonus − 3 dock = 6; varied → no flag; no history → neutral 5; disabled → field absent; custom dock)
- `build_scorecard` end-to-end (top-level mirror present-when-flagged, present-and-false when ran-but-no-flag, absent when disabled)
- `explain.v1` JSON (top-level + per-dim surfaced; format_version stable; field omitted when no collapse)
- explain Markdown (callout emitted; Soft-SVeRL anchor present; **G13 assertion: SWE-bench, MMLU, GSM8K, BIG-bench, HumanEval tokens forbidden**)
- hook gate-mode end-to-end (`warn` → exit 0 + WARNING; `fail` → exit 2 + BLOCKED; `off` → silent)

## Anti-pivot (preserved)

- ✅ **Stdlib-only** — no `requests`, no `anthropic`, no urllib even; the detector is pure list arithmetic
- ✅ **LLM judging stays opt-in / off-by-default** — this is offline-only and is the *companion* to the off-by-default LLM second-opinion
- ✅ **Verdict scores skill executions, not models**

## Anti-cross-pollination G13 (preserved)

- ✅ signal derived from **Verdict's own consistency dimension** plus the **Soft-SVeRL** project anchor
- ✅ no sibling-benchmark analogies — pinned out by `TestExplainMarkdown.test_no_sibling_benchmark_named` (forbids SWE-bench, MMLU, GSM8K, BIG-bench, HumanEval tokens in rendered Markdown)

## Version bump

`2.0.3 → 2.0.4`, synced across `plugin.json`, `marketplace.json`,
`SKILL.md` frontmatter, CHANGELOG heading. README "Latest release"
anchor moved to v2.0.4 per the CHANGELOG-anchor forcing function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)