### PR TITLE
chore: record ProcessScorerJudge PRM-free process-scorer proposal as REJECT-of-record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dispositions of record (rejected proposals)
 
+- **`ProcessScorerJudge` PRM-free step-by-step process scorer with
+  LGS/CGS modes (2026-05-29): REJECT.** A task proposed adding a
+  `ProcessScorerJudge` under `src/judges/` that scores a reasoning
+  trajectory step-by-step using a scorer model's token likelihood
+  rather than a trained PRM: "LGS mode" picks the next step among
+  *k* candidates by the scorer model's likelihood; "CGS mode"
+  scores by contrast between a strong and weak scorer prompt. It
+  asked for a config flag selecting PRM-free process scoring vs the
+  existing outcome judge, tests, README + CHANGELOG, a version
+  bump, and `feat/process-scorer-judge` → push to main, with the
+  test/lint/typecheck runner to be found via `package.json scripts
+  / pyproject / Makefile`. **Rationale for rejection:**
+  (1) **Module surface does not exist.** The task's own suggested
+  grep — `rg "class .*Judge|def judge|src/judges" src` — errors
+  with `IO error ... src: No such file or directory`. There is no
+  `src/` tree, no `class BaseJudge`/`class .*Judge` hierarchy, and
+  no `def judge` interface anywhere in the repo
+  (`rg "class .*Judge\b|BaseJudge|ProcessScorer" --type py` is
+  empty). Verdict's "judge" is `skills/judge/SKILL.md` plus a
+  stdlib heuristic `skills/judge/scripts/score.py` exposing
+  module-level functions (`build_scorecard`, `analyze_dimension`,
+  `compute_composite`) — not an object-oriented judge surface a
+  new subclass could conform to. There is no base-judge signature
+  to capture.
+  (2) **LLM-on-the-hot-path inverts the core invariant.** Both LGS
+  (pick a step by the scorer model's token likelihood) and CGS
+  (strong-vs-weak scorer-prompt contrast) *are* model calls as the
+  scoring mechanism. Verdict is heuristic-first and stdlib-only;
+  the LLM second opinion (`analyzers/llm_judge.py`) is **opt-in and
+  off by default** (`judge-config.json.llm_second_opinion.enabled =
+  false`, `urllib`-only, token-budget-capped). Making a scorer
+  model the judge contradicts the invariant reaffirmed in the
+  v2.0.3 (bench-lint) and v2.0.4 (verifier-collapse) ships:
+  "offline heuristic is the moat; LLM judging stays opt-in."
+  (3) **Scores models, not executions.** A step-by-step
+  reasoning-trajectory process scorer (PRM territory) evaluates a
+  model's *reasoning chain*. Verdict scores *skill / agent
+  execution quality* against rubrics — "verdict scores executions,
+  not models" is a stated product boundary. Process reward models,
+  like the frontier-lab eval-bench scope (SWE-bench, Terminal-Bench,
+  GAIA, OSWorld), are exactly what the 2026-05-03 v4.3 scope reset
+  froze out; re-adding them needs a runbook spec change first
+  ([`CLAUDE.md` §v4.3 Scope Contract](CLAUDE.md#v43-scope-contract-2026-05-03),
+  enforced by `tests/test_v43_scope_contract.py`).
+  (4) **Repo-shape tells.** The task references `src/judges`,
+  `package.json scripts`, `pyproject`, and a `Makefile`-style
+  typecheck runner. Verdict has none of these — no `src/`, no
+  `package.json`, no `pyproject.toml`, no `Makefile`, no
+  `setup.py`; the actual runner is
+  `python3 -m unittest discover tests/` (per `.github/workflows/ci.yml`).
+  Same templated-from-a-different-repo signature as the
+  2026-05-18 `metis_safety` REJECT and the 2026-05-22
+  `held_out_consistency` REJECT (both flagged `pyproject.toml` /
+  `Makefile` / `src/` references absent from this repo).
+  (5) **No anchor verified, and it would not matter.** LGS/CGS
+  ("likelihood-guided" / "contrast-guided" search) and "PRM-free
+  process scoring" were presented without a citation; no source was
+  independently verified at disposition time. The module-surface,
+  invariant, and scope mismatches in (1)–(4) stand regardless of
+  whether such a method exists in the literature. Same shape as
+  prior REJECT-of-record entries: BrowseComp-Plus (2026-05-06),
+  Managed Agents Outcomes rubric beta (2026-05-09), DELEGATE-52
+  (2026-05-10), metis_safety + LangSmith/Cowork (2026-05-18),
+  held_out_consistency (2026-05-22).
+
 - **`held_out_consistency` test-gaming heuristic on the testing
   rubric (2026-05-22): REJECT.** A daily-prompt row proposed
   adding a stdlib-only `held_out_consistency` heuristic that


### PR DESCRIPTION
## Summary

Records the **ProcessScorerJudge / LGS / CGS** proposal as a
**REJECT-of-record** in `CHANGELOG.md` `[Unreleased]` →
*Dispositions of record*. Doc-only; no code, no version bump
(dispositions stay `[Unreleased]`-only, per the existing Notes
convention). Matches the disposition discipline of PRs #30–#33.

## Why rejected (not built)

The task asked for a `ProcessScorerJudge` under `src/judges/` that
scores a reasoning trajectory step-by-step via a scorer model's
token likelihood (LGS: pick next step by likelihood among *k*
candidates; CGS: strong-vs-weak scorer-prompt contrast), PRM-free,
with a config flag, version bump, and `feat/process-scorer-judge` →
push to main. Verification showed the premise does not hold against
this repo:

| Prompt assumes | Reality (`rg`/`ls` evidence) |
|---|---|
| `src/judges/` module | `rg "...|src/judges" src` → **IO error, no such file**. No `src/` tree. |
| `class BaseJudge` / `def judge` interface | `rg "class .*Judge\b\|BaseJudge\|ProcessScorer" --type py` → **empty**. The judge is `SKILL.md` + a stdlib heuristic `score.py` (module functions, not an OO surface). |
| `package.json` / `pyproject` / `Makefile` runner | **None exist**; runner is `python3 -m unittest discover tests/`. |
| scorer-model token-likelihood scoring | LLM call **on the hot path** — inverts the stdlib-only, LLM-opt-in invariant. |

Five-point rationale captured in the CHANGELOG entry:

1. **Module surface does not exist** — no `src/`, no judge class hierarchy, no base signature to conform to.
2. **LLM-on-the-hot-path inverts the core invariant** — LGS/CGS *are* the model call; Verdict keeps LLM judging opt-in/off-by-default (reaffirmed by the v2.0.3 + v2.0.4 ships).
3. **Scores models, not executions** — a PRM-style trajectory scorer is frontier-lab eval-bench scope frozen out by the v4.3 reset (`tests/test_v43_scope_contract.py`).
4. **Repo-shape tells** — `src/judges` / `package.json` / `pyproject` / `Makefile` references are the same templated-from-a-different-repo signature as the `metis_safety` (2026-05-18) and `held_out_consistency` (2026-05-22) REJECTs.
5. **No anchor verified, and it would not matter** — the surface/invariant/scope mismatches stand regardless.

## Test plan

```shell
python3 -m unittest discover tests/        # 591/591 pass (doc-only change)
python3 -m unittest tests.test_version_consistency tests.test_readme_release_anchor tests.test_v43_scope_contract  # green
```

Version stamps deliberately unchanged at `2.0.4` (a disposition is
not a release). CHANGELOG release headings (`[2.0.4]`, `[2.0.3]`, …)
untouched, so the version-consistency + README-anchor forcing
functions stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)