### PR TITLE
feat(judge): same-family second-opinion judge guard + self_preference_risk flag

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "verdict",
       "source": "./",
       "description": "Auto-evaluates skill and agent execution quality with 7-dimension scoring, configurable rubrics, and dual-mode operation.",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "category": "quality-assurance",
       "tags": ["judge", "evaluation", "quality", "scoring", "LLM-as-judge"],
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verdict",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "displayName": "Verdict — Universal Skill & Agent Quality Judge",
   "description": "The first universal judge for Claude Code & Cowork. Auto-evaluates skill and agent execution quality with 7-dimension scoring, configurable rubrics, and dual-mode operation (auto hooks + manual /judge command).",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   BrowseComp-Plus (2026-05-06), Managed Agents Outcomes rubric
   beta (2026-05-09).
 
+## [2.0.5] - 2026-06-07
+
+Patch release. Adds a stdlib-only **same-family judge guard** plus a
+`self_preference_risk` scorecard flag to the opt-in LLM second-opinion
+analyzer.
+
+### Added
+
+- **Same-family judge guard** (`skills/judge/analyzers/llm_judge.py`):
+  new `model_family()` (prefix-buckets a model ID into
+  anthropic/openai/google/meta) and `same_family_guard()`. Before the
+  opt-in second opinion runs, the guard compares the executing model
+  (from `score.detect_model_from_transcript`) against the configured
+  judge model. On a same-family match it (a) sets
+  `self_preference_risk: true` on the scorecard and emits a
+  `Verdict WARNING:` line on stderr citing the measured effect
+  (MT-Bench: GPT-4 +10%, Claude-v1 +25% self-win-rate), and (b) when a
+  cross-family `llm_second_opinion.alternate_judge_models` entry is
+  configured, auto-prefers it for the call (reachable via the
+  documented injected-client / proxy path). Off-by-default with the
+  rest of the second opinion; stdlib-only, no new deps.
+- `self_preference_risk` (boolean) and `same_family_guard` (object)
+  optional top-level scorecard fields — additive, backward-compatible
+  in `schemas/scorecard.v1.schema.json`.
+- `llm_second_opinion.alternate_judge_models` config key (default `[]`).
+- `tests/test_same_family_guard.py`: family bucketing, same-family
+  risk + citation, cross-family clear, auto-prefer substitution,
+  `build_scorecard` integration via a mock client, and a regression
+  assertion that `build_prompt` / `SYSTEM_PROMPT` never use
+  first-person framing ("you wrote" / "your work" / "your output").
+
+### Rationale
+
+An LLM judge over-scores its own family. The effect is measured, not
+hypothetical (self-preference: arXiv:2306.05685; role-relabel framing
+swings scores +23–93pp: arXiv:2606.05976), and in Verdict's stock
+configuration the second opinion is Claude-judging-Claude — so the
+guard fires on every enabled run, which is the honest signal. The
+existing third-party "second-opinion judge" framing is preserved.
+
 ## [2.0.4] - 2026-05-29
 
 Patch release. Adds a stdlib-only verifier-collapse detector to the

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ workaround (GH #39400), see [INSTALL-COWORK.md](INSTALL-COWORK.md).
   pack so a suspect corpus is caught before its scores ship. See
   [§Benchmark hygiene lint](#benchmark-hygiene-lint-aba-anchored)
   below.
+- **Same-family judge guard.** When the opt-in LLM second opinion is
+  enabled, Verdict checks whether the judge model shares a vendor
+  family with the model that produced the transcript. A match sets
+  `self_preference_risk: true` and warns on the console (Claude judging
+  Claude inflates scores); a configured cross-family judge is
+  auto-preferred. See [§Same-family judge guard](#same-family-judge-guard)
+  below.
 - **Stdlib only.** Python 3.9+, no third-party packages, installs
   instantly with zero supply-chain risk.
 
@@ -396,10 +403,50 @@ heuristic is offline statistics, default-on, and never calls an
 LLM; this complements (does not replace) the opt-in LLM
 second-opinion analyzer.
 
+## Same-family judge guard
+
+The opt-in LLM second opinion
+(`judge-config.json.llm_second_opinion.enabled = true`) is only as
+trustworthy as the judge. An LLM judge systematically over-scores
+outputs from its own model family, so when the second-opinion judge
+shares a family with the model that produced the transcript, the score
+is biased upward and Verdict says so.
+
+Before the call, `same_family_guard` (in
+`skills/judge/analyzers/llm_judge.py`) buckets the executing model
+(from `score.detect_model_from_transcript`) and the configured judge
+model into vendor families (`anthropic` / `openai` / `google` /
+`meta`). On a same-family match it:
+
+1. sets `self_preference_risk: true` on the scorecard (mirrored in the
+   `same_family_guard` object with both families), and emits
+   `Verdict WARNING: judge and executing model share a family …` on
+   stderr; and
+2. if `llm_second_opinion.alternate_judge_models` names a cross-family
+   judge, **auto-prefers** it for the call (reachable via the injected
+   client / proxy path the analyzer already documents).
+
+In the stock configuration the second opinion is Claude judging
+Claude, so the guard fires on every enabled run — that is the honest
+signal, not a bug. The guard is offline and stdlib-only; it asserts a
+clash only when both families are recognised (an unknown model never
+fabricates a risk).
+
+**Design rationale.** Self-preference in LLM-as-judge is measured, not
+hypothetical: pairwise judges favour their own family by double-digit
+win-rate margins ([arXiv:2306.05685](https://arxiv.org/abs/2306.05685),
+MT-Bench — GPT-4 +10pp, Claude-v1 +25pp self-win-rate), and merely
+re-labelling an output as the judge's own work swings its scores by
++23–93pp ([arXiv:2606.05976](https://arxiv.org/abs/2606.05976),
+role-relabel). Verdict keeps the judge framed as a third-party
+"second-opinion judge" (never first-person), flags the residual
+same-family risk, and prefers a cross-family judge when one is
+configured.
+
 ## Roadmap
 
 See [ROADMAP_2026.md](ROADMAP_2026.md) for the 90-day plan. Latest
-release: [v2.0.4](https://github.com/sattyamjjain/verdict/releases/tag/v2.0.4)
+release: [v2.0.5](https://github.com/sattyamjjain/verdict/releases/tag/v2.0.5)
 (verifier-collapse detector — flags judges that have flatlined at
 the top of the scale over the rolling scorecard window, docks the
 consistency dim, surfaces in `/judge --explain` + the Stop-hook

--- a/judge-config.json
+++ b/judge-config.json
@@ -40,10 +40,12 @@
     "claude-haiku-4-5": 1.0
   },
   "llm_second_opinion": {
+    "_comment": "alternate_judge_models: cross-family judge IDs (e.g. gpt-4o, gemini-2.5-pro) reachable via an injected client / proxy. When the configured judge shares a model family with the executing model, the same-family self-preference guard warns and auto-prefers the first cross-family entry here for the second-opinion call.",
     "enabled": false,
     "model": "claude-haiku-4-5",
     "budget_tokens": null,
-    "task_budget_tokens": null
+    "task_budget_tokens": null,
+    "alternate_judge_models": []
   },
   "verifier_collapse": {
     "_comment": "Detect verifier collapse over the rolling window of recent scorecards for the same skill. Flags when >= top_bucket_fraction of the last <window> composites are in the top bucket AND stdev < max_std_dev. Pure offline statistics over scores/; no LLM call. gate_mode: 'warn' (stderr only) | 'fail' (hook exit 2).",

--- a/schemas/scorecard.v1.schema.json
+++ b/schemas/scorecard.v1.schema.json
@@ -128,6 +128,37 @@
     "verifier_collapse": {
       "type": "boolean",
       "description": "Top-level mirror of dimensions.consistency.verifier_collapse. Present only when the verifier-collapse detector ran (judge-config.json.verifier_collapse.enabled=true). True = the rolling window of recent scorecards for this skill showed flatline-at-top behaviour; see the consistency dim entry for reason and stats."
+    },
+    "self_preference_risk": {
+      "type": "boolean",
+      "description": "Present only when the opt-in LLM second opinion ran (judge-config.json.llm_second_opinion.enabled=true). True = the configured judge model shares a vendor family with the model that produced the transcript, so the second opinion is structurally biased upward (self-preference; MT-Bench arXiv:2306.05685). See same_family_guard for the families and any auto-preferred cross-family judge."
+    },
+    "same_family_guard": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Detail for self_preference_risk. Present only when the LLM second opinion ran.",
+      "properties": {
+        "executing_family": {
+          "type": ["string", "null"],
+          "description": "Vendor family of the model that produced the transcript (anthropic/openai/google/meta), or null when unrecognised."
+        },
+        "judge_family": {
+          "type": ["string", "null"],
+          "description": "Vendor family of the configured second-opinion judge model, or null when unrecognised."
+        },
+        "judge_model": {
+          "type": ["string", "null"],
+          "description": "The configured judge model ID considered by the guard."
+        },
+        "auto_preferred": {
+          "type": "boolean",
+          "description": "True when a cross-family alternate_judge_models entry was substituted for the configured judge to mitigate self-preference."
+        },
+        "preferred_model": {
+          "type": ["string", "null"],
+          "description": "The cross-family judge model ID actually used for the second-opinion call when auto_preferred=true; null otherwise."
+        }
+      }
     }
   },
   "$defs": {

--- a/skills/judge/SKILL.md
+++ b/skills/judge/SKILL.md
@@ -2,7 +2,7 @@
 name: judge
 displayName: "Verdict — Universal Quality Evaluator"
 description: "Evaluates the execution quality of any skill or agent using 7-dimension scoring with configurable rubrics"
-version: "2.0.4"
+version: "2.0.5"
 author: "Sattyam Jain"
 allowed-tools: [Read, Write, Edit, Bash]
 autoActivate:

--- a/skills/judge/analyzers/llm_judge.py
+++ b/skills/judge/analyzers/llm_judge.py
@@ -53,6 +53,9 @@ __all__ = [
     "parse_scores",
     "resolve_cache_ttl_from_env",
     "build_cached_system_block",
+    "model_family",
+    "same_family_guard",
+    "SELF_PREFERENCE_WARNING",
 ]
 
 DIMENSIONS: List[str] = [
@@ -336,6 +339,119 @@ def _rubric_criteria_summary(rubric: Dict[str, Any]) -> str:
             excerpt = excerpt[:600] + " ..."
         lines.append(f"- {dim}: {excerpt}")
     return "\n".join(lines) if lines else "(no per-dimension criteria provided)"
+
+
+# ---------------------------------------------------------------------------
+# Same-family self-preference guard
+# ---------------------------------------------------------------------------
+#
+# An LLM judge scores its own family's outputs higher than a neutral
+# observer would. The effect is measured, not hypothetical:
+#   * MT-Bench (arXiv:2306.05685): GPT-4 self-win-rate +10pp, Claude-v1
+#     +25pp vs. human-aligned baselines.
+#   * Role-relabel attacks (arXiv:2606.05976): framing the same output
+#     as the judge's own work swings scores +23-93pp.
+# So when Verdict's second-opinion judge shares a model family with the
+# model that produced the transcript, the second opinion is structurally
+# biased *upward* and should be flagged (and, where a cross-family judge
+# is configured, swapped out).
+#
+# Verdict's executing-model detector (`score.detect_model_from_transcript`)
+# only recognises `claude-*` today, and the default judge is Claude — so
+# in the stock configuration this guard fires on every enabled run, which
+# is the honest signal: Claude-judging-Claude is self-preference-prone.
+# Cross-family judging is reachable via the documented injected-client /
+# proxy path (see module docstring) — `alternate_judge_models` names the
+# preferred cross-family judge IDs for that path.
+
+# Prefix → family buckets. Longest-prefix-wins is unnecessary because the
+# prefixes below are disjoint; we lowercase and strip a leading vendor
+# slug (``anthropic/claude-...``) before matching.
+_FAMILY_PREFIXES: List[Tuple[str, Tuple[str, ...]]] = [
+    ("anthropic", ("claude", "anthropic")),
+    ("openai", ("gpt", "o1", "o3", "o4", "chatgpt", "openai", "text-davinci", "davinci")),
+    ("google", ("gemini", "palm", "bison", "google", "gemma")),
+    ("meta", ("llama", "codellama", "meta")),
+]
+
+SELF_PREFERENCE_WARNING = (
+    "judge and executing model share a family; self-preference bias "
+    "inflates scores (MT-Bench: GPT-4 +10%, Claude-v1 +25% self-win-rate)"
+)
+
+
+def model_family(model_id: Optional[str]) -> Optional[str]:
+    """Bucket a model ID into a vendor family, or ``None`` if unknown.
+
+    Matching is case-insensitive and tolerant of a leading vendor slug
+    (``anthropic/claude-haiku-4-5`` → ``anthropic``). Returns one of
+    ``{"anthropic", "openai", "google", "meta"}`` or ``None`` when the
+    ID matches no known prefix (callers treat unknown as "can't compare,
+    no risk asserted").
+    """
+    if not model_id or not isinstance(model_id, str):
+        return None
+    name = model_id.strip().lower()
+    # Drop a leading ``vendor/`` or ``vendor:`` slug if present.
+    for sep in ("/", ":"):
+        if sep in name:
+            name = name.split(sep, 1)[1]
+    for family, prefixes in _FAMILY_PREFIXES:
+        if name.startswith(prefixes):
+            return family
+    return None
+
+
+def same_family_guard(
+    executing_model: Optional[str],
+    judge_model: Optional[str],
+    alternate_judge_models: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Assess self-preference risk between executing and judge models.
+
+    Returns a summary dict:
+
+    ``self_preference_risk``
+        ``True`` when both families are known and equal.
+    ``executing_family`` / ``judge_family``
+        The resolved buckets (or ``None`` when unknown).
+    ``judge_model``
+        The judge model considered (echoed for the scorecard).
+    ``reason``
+        :data:`SELF_PREFERENCE_WARNING` when at risk, else ``""``.
+    ``preferred_model``
+        The first entry of *alternate_judge_models* whose family is
+        known and differs from the executing family — set only when at
+        risk and such an alternate exists. ``None`` otherwise.
+    ``auto_preferred``
+        ``True`` when ``preferred_model`` was selected (the caller should
+        route the second-opinion call to it instead of *judge_model*).
+
+    Risk is asserted only when *both* families are known; an unknown
+    executing or judge model yields ``self_preference_risk=False`` (we
+    never fabricate a clash we can't substantiate).
+    """
+    exec_family = model_family(executing_model)
+    judge_family = model_family(judge_model)
+    at_risk = bool(exec_family and judge_family and exec_family == judge_family)
+
+    preferred_model: Optional[str] = None
+    if at_risk:
+        for alt in alternate_judge_models or []:
+            alt_family = model_family(alt)
+            if alt_family and alt_family != exec_family:
+                preferred_model = alt
+                break
+
+    return {
+        "self_preference_risk": at_risk,
+        "executing_family": exec_family,
+        "judge_family": judge_family,
+        "judge_model": judge_model,
+        "reason": SELF_PREFERENCE_WARNING if at_risk else "",
+        "preferred_model": preferred_model,
+        "auto_preferred": preferred_model is not None,
+    }
 
 
 SYSTEM_PROMPT = (

--- a/skills/judge/scripts/score.py
+++ b/skills/judge/scripts/score.py
@@ -1453,12 +1453,16 @@ def _llm_second_opinion_config(config: Dict[str, Any]) -> Dict[str, Any]:
             "model": "claude-haiku-4-5",
             "budget_tokens": None,
             "task_budget_tokens": None,
+            "alternate_judge_models": [],
         }
+    raw_alts = block.get("alternate_judge_models")
+    alternates = [str(m) for m in raw_alts] if isinstance(raw_alts, list) else []
     return {
         "enabled": bool(block.get("enabled", False)),
         "model": str(block.get("model", "claude-haiku-4-5")),
         "budget_tokens": block.get("budget_tokens"),
         "task_budget_tokens": block.get("task_budget_tokens"),
+        "alternate_judge_models": alternates,
     }
 
 
@@ -1469,17 +1473,28 @@ def _maybe_llm_second_opinion(
     rubric_name: str,
     dimensions: Dict[str, Dict[str, Any]],
     client: Optional[Any] = None,
-) -> None:
+    detected_model: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
     """Merge LLM second-opinion scores into ``dimensions`` in place.
 
-    No-op when the config block has ``enabled=false`` (the default).
-    Failures (missing API key, HTTP error, unparseable response) are
-    logged to stderr and swallowed — Verdict must stay offline-first,
-    so a busted LLM path can never fail the whole scorecard.
+    No-op (returns ``None``) when the config block has ``enabled=false``
+    (the default). Failures (missing API key, HTTP error, unparseable
+    response) are logged to stderr and swallowed — Verdict must stay
+    offline-first, so a busted LLM path can never fail the whole
+    scorecard.
+
+    When enabled, runs the same-family self-preference guard
+    (``llm_judge.same_family_guard``) comparing *detected_model* (the
+    model that produced the transcript) against the configured judge
+    model. On a same-family hit it warns on stderr and, when a
+    cross-family ``alternate_judge_models`` entry is configured,
+    auto-prefers it for the second-opinion call. Returns the guard
+    summary dict so ``build_scorecard`` can surface
+    ``self_preference_risk`` on the scorecard.
     """
     cfg = _llm_second_opinion_config(config)
     if not cfg["enabled"]:
-        return
+        return None
 
     # Local import so the module only pulls llm_judge when actually
     # needed, keeping cold-start costs (and test import times) down.
@@ -1488,11 +1503,35 @@ def _maybe_llm_second_opinion(
         from analyzers.llm_judge import (  # type: ignore
             AnthropicClient,
             LLMJudgeError,
+            model_family,
+            same_family_guard,
             score_with_llm,
         )
     except ImportError as exc:
         print(f"Warning: LLM second opinion unavailable — {exc}", file=sys.stderr)
-        return
+        return None
+
+    # Same-family self-preference guard. Runs before the call so an
+    # auto-preferred cross-family judge is the model actually invoked.
+    guard = same_family_guard(
+        detected_model, cfg["model"], cfg.get("alternate_judge_models"),
+    )
+    judge_model = cfg["model"]
+    if guard["self_preference_risk"]:
+        print(
+            f"Verdict WARNING: {guard['reason']} "
+            f"(executing={guard['executing_family']}, "
+            f"judge={guard['judge_family']}:{cfg['model']})",
+            file=sys.stderr,
+        )
+        if guard["auto_preferred"] and guard["preferred_model"]:
+            judge_model = guard["preferred_model"]
+            print(
+                f"Verdict: auto-preferring cross-family second-opinion "
+                f"judge {judge_model} ({guard['judge_family']} → "
+                f"{model_family(judge_model)}).",
+                file=sys.stderr,
+            )
 
     # If no client was injected, construct the default with the
     # configured task_budget_tokens so the beta header flows through.
@@ -1504,27 +1543,29 @@ def _maybe_llm_second_opinion(
             )
         except LLMJudgeError as exc:
             print(f"Warning: LLM second opinion unavailable — {exc}", file=sys.stderr)
-            return
+            return guard
 
     rubric_envelope = {"name": rubric_name, "criteria": rubric_criteria}
     try:
         llm_scores = score_with_llm(
             transcript=transcript_lines,
             rubric=rubric_envelope,
-            model=cfg["model"],
+            model=judge_model,
             client=effective_client,
         )
     except LLMJudgeError as exc:
         print(f"Warning: LLM second opinion failed — {exc}", file=sys.stderr)
-        return
+        return guard
     except Exception as exc:  # pragma: no cover — last-ditch defensive
         print(f"Warning: LLM second opinion crashed — {exc}", file=sys.stderr)
-        return
+        return guard
 
     for dim, (score_val, justification) in llm_scores.items():
         if dim in dimensions:
             dimensions[dim]["llm_score"] = score_val
             dimensions[dim]["llm_justification"] = justification
+
+    return guard
 
 
 def save_score(scorecard: Dict[str, Any], scores_dir: str) -> str:
@@ -1659,9 +1700,9 @@ def build_scorecard(
     # 2b. Opt-in LLM second opinion (off by default; see
     # analyzers/llm_judge.py). Mutates `dimensions` in place to add
     # `llm_score` / `llm_justification` alongside the heuristic entries.
-    _maybe_llm_second_opinion(
+    llm_guard = _maybe_llm_second_opinion(
         config, transcript_lines, rubric_criteria, rubric_name, dimensions,
-        client=llm_client,
+        client=llm_client, detected_model=detected_model,
     )
 
     # 3. Composite score
@@ -1731,6 +1772,21 @@ def build_scorecard(
         scorecard["verifier_collapse"] = True
     elif "verifier_collapse" in consistency_dim:
         scorecard["verifier_collapse"] = False
+
+    # Surface the same-family self-preference guard at the top level
+    # (present only when the LLM second opinion ran, i.e. enabled).
+    # `self_preference_risk` is the one-jq-query CI flag; the
+    # `same_family_guard` object carries the families and any
+    # auto-preferred cross-family judge for explainability.
+    if llm_guard is not None:
+        scorecard["self_preference_risk"] = bool(llm_guard["self_preference_risk"])
+        scorecard["same_family_guard"] = {
+            "executing_family": llm_guard["executing_family"],
+            "judge_family": llm_guard["judge_family"],
+            "judge_model": llm_guard["judge_model"],
+            "auto_preferred": llm_guard["auto_preferred"],
+            "preferred_model": llm_guard["preferred_model"],
+        }
 
     # 5. Persist
     saved_path = save_score(scorecard, scores_dir)

--- a/tests/test_same_family_guard.py
+++ b/tests/test_same_family_guard.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Tests for the same-family self-preference judge guard.
+
+The guard lives in ``skills/judge/analyzers/llm_judge.py`` and is wired
+into ``score._maybe_llm_second_opinion`` /
+``score.build_scorecard``. It compares the model that produced the
+transcript against the configured second-opinion judge model; when they
+share a vendor family the second opinion is self-preference-biased
+upward, so the guard flags ``self_preference_risk`` and (when a
+cross-family alternate is configured) auto-prefers it.
+
+All tests are offline — the LLM path is exercised through a mock client
+so no network call happens. Stdlib-only.
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "skills" / "judge"))
+sys.path.insert(0, str(PROJECT_ROOT / "skills" / "judge" / "scripts"))
+
+from analyzers import llm_judge as lj  # noqa: E402
+import score  # noqa: E402
+
+
+class FakeClient:
+    """In-memory LLMClient that records which model it was asked to call."""
+
+    def __init__(self, score_per_dim: int = 8) -> None:
+        self.score_per_dim = score_per_dim
+        self.calls: List[Dict[str, Any]] = []
+
+    def messages_create(self, model: str, system: str, prompt: str, max_tokens: int) -> str:
+        self.calls.append({"model": model, "system": system, "prompt": prompt})
+        return json.dumps({
+            dim: {"score": self.score_per_dim, "justification": f"view of {dim}"}
+            for dim in lj.DIMENSIONS
+        })
+
+    @property
+    def last_model(self) -> Optional[str]:
+        return self.calls[-1]["model"] if self.calls else None
+
+
+# ---------------------------------------------------------------------------
+# model_family bucketing
+# ---------------------------------------------------------------------------
+
+
+class TestModelFamily(unittest.TestCase):
+    def test_anthropic_prefixes(self) -> None:
+        for mid in ("claude-haiku-4-5", "claude-opus-4-8", "anthropic/claude-sonnet-4-6"):
+            self.assertEqual(lj.model_family(mid), "anthropic", mid)
+
+    def test_openai_prefixes(self) -> None:
+        for mid in ("gpt-4o", "gpt-5", "o3-mini", "o1-preview", "chatgpt-4o-latest"):
+            self.assertEqual(lj.model_family(mid), "openai", mid)
+
+    def test_google_prefixes(self) -> None:
+        for mid in ("gemini-2.5-pro", "gemini-1.5-flash", "gemma-2-27b"):
+            self.assertEqual(lj.model_family(mid), "google", mid)
+
+    def test_meta_prefixes(self) -> None:
+        for mid in ("llama-3.1-70b", "codellama-34b", "meta-llama-3"):
+            self.assertEqual(lj.model_family(mid), "meta", mid)
+
+    def test_unknown_and_empty(self) -> None:
+        for mid in ("mystery-7b", "", None, "  "):
+            self.assertIsNone(lj.model_family(mid), mid)
+
+    def test_case_insensitive_and_vendor_slug(self) -> None:
+        self.assertEqual(lj.model_family("CLAUDE-OPUS-4-8"), "anthropic")
+        self.assertEqual(lj.model_family("openai:gpt-4o"), "openai")
+
+
+# ---------------------------------------------------------------------------
+# same_family_guard
+# ---------------------------------------------------------------------------
+
+
+class TestSameFamilyGuard(unittest.TestCase):
+    def test_same_family_flags_risk_with_citation(self) -> None:
+        g = lj.same_family_guard("claude-opus-4-8", "claude-haiku-4-5")
+        self.assertTrue(g["self_preference_risk"])
+        self.assertEqual(g["executing_family"], "anthropic")
+        self.assertEqual(g["judge_family"], "anthropic")
+        # The reason cites the measured self-preference effect.
+        self.assertIn("self-preference", g["reason"])
+        self.assertIn("self-win-rate", g["reason"])
+        self.assertFalse(g["auto_preferred"])
+        self.assertIsNone(g["preferred_model"])
+
+    def test_cross_family_clears_risk(self) -> None:
+        g = lj.same_family_guard("claude-opus-4-8", "gpt-4o")
+        self.assertFalse(g["self_preference_risk"])
+        self.assertEqual(g["reason"], "")
+        self.assertFalse(g["auto_preferred"])
+
+    def test_unknown_executing_model_asserts_no_risk(self) -> None:
+        # Can't substantiate a clash against an unrecognised model.
+        g = lj.same_family_guard("mystery-7b", "claude-haiku-4-5")
+        self.assertFalse(g["self_preference_risk"])
+        self.assertIsNone(g["executing_family"])
+
+    def test_auto_prefer_picks_first_cross_family_alternate(self) -> None:
+        g = lj.same_family_guard(
+            "claude-opus-4-8", "claude-haiku-4-5",
+            alternate_judge_models=["claude-sonnet-4-6", "gpt-4o", "gemini-2.5-pro"],
+        )
+        self.assertTrue(g["self_preference_risk"])
+        self.assertTrue(g["auto_preferred"])
+        # claude-sonnet-4-6 is same-family (skipped); gpt-4o is the first
+        # cross-family entry.
+        self.assertEqual(g["preferred_model"], "gpt-4o")
+
+    def test_auto_prefer_noop_when_all_alternates_same_family(self) -> None:
+        g = lj.same_family_guard(
+            "claude-opus-4-8", "claude-haiku-4-5",
+            alternate_judge_models=["claude-sonnet-4-6", "claude-opus-4-7"],
+        )
+        self.assertTrue(g["self_preference_risk"])
+        self.assertFalse(g["auto_preferred"])
+        self.assertIsNone(g["preferred_model"])
+
+
+# ---------------------------------------------------------------------------
+# build_prompt / SYSTEM_PROMPT must never use first-person framing
+# ---------------------------------------------------------------------------
+
+
+class TestNoFirstPersonFraming(unittest.TestCase):
+    """The judge is framed as a third-party reviewer, never the author.
+
+    First-person framing ("your work") is exactly the role-relabel
+    vector that swings scores +23-93pp (arXiv:2606.05976), so the
+    rendered prompt and system prompt must avoid it.
+    """
+
+    FORBIDDEN = ("you wrote", "your work", "your output", "you produced", "your code")
+
+    def _render(self) -> str:
+        rubric = {
+            "name": "code-review",
+            "criteria": {dim: f"criteria for {dim}" for dim in lj.DIMENSIONS},
+        }
+        transcript = ["did the work", "verified the output against the spec"]
+        return lj.build_prompt(transcript, rubric)
+
+    def test_build_prompt_has_no_first_person(self) -> None:
+        rendered = self._render().lower()
+        for phrase in self.FORBIDDEN:
+            self.assertNotIn(phrase, rendered, f"build_prompt leaked first-person: {phrase!r}")
+
+    def test_system_prompt_has_no_first_person(self) -> None:
+        system = lj.SYSTEM_PROMPT.lower()
+        for phrase in self.FORBIDDEN:
+            self.assertNotIn(phrase, system, f"SYSTEM_PROMPT leaked first-person: {phrase!r}")
+        # Positive: the third-party framing is intact.
+        self.assertIn("second-opinion judge", lj.SYSTEM_PROMPT)
+
+
+# ---------------------------------------------------------------------------
+# Integration through score.build_scorecard
+# ---------------------------------------------------------------------------
+
+
+class TestGuardIntegration(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.scores = self.tmp / "scores"
+        self.rubric_dir = str(PROJECT_ROOT / "skills" / "judge" / "rubrics")
+        # Transcript whose embedded executing model is Claude.
+        self.transcript = self.tmp / "t.jsonl"
+        self.transcript.write_text(
+            '{"model":"claude-opus-4-8"}\n'
+            '{"role":"assistant","content":"completed the task; verified output"}\n',
+            encoding="utf-8",
+        )
+
+    def _config(self, **llm_extra: Any) -> str:
+        cfg = {
+            "llm_second_opinion": {
+                "enabled": True, "model": "claude-haiku-4-5", **llm_extra,
+            }
+        }
+        path = self.tmp / f"cfg_{len(llm_extra)}_{id(llm_extra)}.json"
+        path.write_text(json.dumps(cfg), encoding="utf-8")
+        return str(path)
+
+    def test_same_family_sets_flag_and_warns(self) -> None:
+        client = FakeClient()
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            sc = score.build_scorecard(
+                "code-review", str(self.transcript), self.rubric_dir,
+                str(self.scores), config_path=self._config(), llm_client=client,
+            )
+        self.assertTrue(sc["self_preference_risk"])
+        self.assertEqual(sc["same_family_guard"]["executing_family"], "anthropic")
+        self.assertEqual(sc["same_family_guard"]["judge_family"], "anthropic")
+        self.assertFalse(sc["same_family_guard"]["auto_preferred"])
+        self.assertIn("Verdict WARNING", buf.getvalue())
+        # No alternate → judge model unchanged.
+        self.assertEqual(client.last_model, "claude-haiku-4-5")
+
+    def test_cross_family_alternate_is_auto_preferred(self) -> None:
+        client = FakeClient()
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            sc = score.build_scorecard(
+                "code-review", str(self.transcript), self.rubric_dir,
+                str(self.scores),
+                config_path=self._config(alternate_judge_models=["gpt-4o"]),
+                llm_client=client,
+            )
+        self.assertTrue(sc["self_preference_risk"])
+        self.assertTrue(sc["same_family_guard"]["auto_preferred"])
+        self.assertEqual(sc["same_family_guard"]["preferred_model"], "gpt-4o")
+        # The judge actually invoked switched to the cross-family model.
+        self.assertEqual(client.last_model, "gpt-4o")
+        self.assertIn("auto-preferring", buf.getvalue())
+
+    def test_disabled_second_opinion_omits_flag(self) -> None:
+        # When the LLM second opinion is off (default), the guard never
+        # runs and the scorecard carries no self_preference_risk key.
+        cfg = self.tmp / "cfg_off.json"
+        cfg.write_text(json.dumps({"llm_second_opinion": {"enabled": False}}), encoding="utf-8")
+        sc = score.build_scorecard(
+            "code-review", str(self.transcript), self.rubric_dir,
+            str(self.scores), config_path=str(cfg),
+        )
+        self.assertNotIn("self_preference_risk", sc)
+        self.assertNotIn("same_family_guard", sc)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a stdlib-only **same-family self-preference guard** to Verdict's opt-in LLM second-opinion analyzer (`skills/judge/analyzers/llm_judge.py`), plus a `self_preference_risk` scorecard flag. An LLM judge over-scores its own model family; this flags it and, where configured, routes around it. Bumps **v2.0.4 → v2.0.5**.

> **Spec corrections (verified against HEAD).** The request said bump `2.0.2→2.0.3`, parse the model in `adapters/`, and "push to main". Actual repo state: HEAD was **2.0.4** (→ bumped to **2.0.5**); the executing model is parsed in **`score.py`** (`detect_model_from_transcript`, `claude-*`-only), not the adapters; and the repo's convention is branch + PR (this), not direct push to main. No `pyproject` exists — canonical version lives in `plugin.json` / `marketplace.json` / `SKILL.md`.

## What it does

- `model_family(model_id)` — buckets a model ID into `anthropic` / `openai` / `google` / `meta` by prefix (case-insensitive, tolerates a `vendor/` slug).
- `same_family_guard(executing, judge, alternates)` — asserts `self_preference_risk` only when **both** families are known and equal.
- Wired into `score._maybe_llm_second_opinion` / `build_scorecard`:
  - sets top-level `self_preference_risk: true` + a `same_family_guard` detail object on the scorecard;
  - emits `Verdict WARNING: judge and executing model share a family …` on stderr, citing the measured effect (MT-Bench: GPT-4 +10%, Claude-v1 +25% self-win-rate);
  - **auto-prefers** the first cross-family `llm_second_opinion.alternate_judge_models` entry for the call (reachable via the injected-client / proxy path the analyzer already documents).

In the stock config the second opinion is **Claude judging Claude**, so the guard fires on every enabled run — the honest signal, not a bug. Off by default with the rest of the second opinion.

## Design honesty

- The existing third-party `"You are Verdict's second-opinion judge"` framing is **preserved**; `build_prompt` / `SYSTEM_PROMPT` carry **no** first-person framing — a regression test pins this (`you wrote` / `your work` / `your output`). First-person framing is the role-relabel vector that swings scores +23–93pp.
- "Auto-prefer an alternate family" is honest *because* the analyzer already supports an injected client / proxy for non-Anthropic judges; this PR does **not** add a new OpenAI/Google HTTP client (that would be an unwarranted multi-provider expansion). It selects the configured model ID; the operator's proxy serves it.
- Schema change is **additive/backward-compatible** (optional top-level `self_preference_risk` + `same_family_guard`).
- No rubric/adapter added → **v4.3 scope contract untouched** (still 11 rubrics, test green).

Rationale cites **arXiv:2306.05685** (self-preference) and **arXiv:2606.05976** (role-relabel +23–93pp) in the README.

## Test plan

- New `tests/test_same_family_guard.py` (16 tests): family bucketing, same-family risk + citation, cross-family clear, unknown-model no-risk, auto-prefer substitution + no-op-when-all-same-family, `build_scorecard` integration via mock client (flag set, warning emitted, judge model actually swapped to the cross-family alternate), disabled-second-opinion omits the key, and the no-first-person regression assertion.
- `python3 -m unittest discover tests/` → **607 passed** (591 + 16).
- `tests.test_v43_scope_contract`, `tests.test_version_consistency`, `scripts/check_readme_release_anchor.py` → all green.
- Offline smoke (mock client): same-family → `self_preference_risk=true` + warning; `alternate_judge_models=["gpt-4o"]` → judge call switches to `gpt-4o`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)