### PR TITLE
fix(score): harden adherence and correctness against trivial gaming

### DIFF
--- a/skills/judge/scripts/score.py
+++ b/skills/judge/scripts/score.py
@@ -715,8 +715,21 @@ def _analyze_correctness(
             f"{us_findings[0]['claim']!r}"
         )
 
+    # Heuristic correctness cannot *confirm* functional correctness — it only
+    # detects negative signals (errors, hallucinations, fabricated success).
+    # A clean transcript that simply avoids the word "error" must therefore
+    # not earn a perfect 10: the top mark requires at least one execution
+    # receipt (a test run, an exit code — the same artefacts
+    # ``detect_unverified_success`` looks for). Without any verification
+    # evidence the score is capped at 9, so "say nothing and avoid 'error'"
+    # no longer scores a clean 10. Legitimately untestable tasks still reach
+    # 9. (Proofloop: no pass without proof.)
+    if score >= 10 and not _US_RECEIPT.search("\n".join(lines)):
+        score = 9
+        reasons.append("No executed-verification evidence — perfect score withheld")
+
     score = max(1, min(10, score))
-    justification = "; ".join(reasons) if reasons else "No error or hallucination signals detected"
+    justification = "; ".join(reasons) if reasons else "No errors; verification receipt present"
     result: Dict[str, Any] = {"score": score, "justification": justification}
     if us_findings:
         result["unverified_success"] = us_findings
@@ -819,15 +832,21 @@ def _analyze_adherence(
         score -= 1
         reasons.append(f"Minor deviation signals ({deviation_count} hits)")
 
-    # If rubric criteria exist, check for structural compliance
+    # A rubric being *available* is not evidence the run complied with it.
+    # The old heuristic added +1 here on every run that loaded a rubric —
+    # i.e. always — inflating adherence to 9 regardless of behaviour, even
+    # for a run that ignored every instruction (as long as it avoided the
+    # deviation keywords above). Heuristic adherence can only detect
+    # *deviation* (a negative signal); positive compliance must be earned and
+    # is scored against the rubric criteria directly by the opt-in LLM tier.
+    # So we record the rubric context but award no unearned credit.
     if rubric_criteria:
-        score = min(score + 1, 10)
-        reasons.append("Rubric criteria available for evaluation context")
+        reasons.append("Rubric available (compliance scored by LLM tier, not assumed)")
     else:
-        reasons.append("No specific rubric criteria — using generic adherence check")
+        reasons.append("No specific rubric criteria — generic deviation check only")
 
     score = max(1, min(10, score))
-    justification = "; ".join(reasons) if reasons else "Instructions appear to be followed"
+    justification = "; ".join(reasons) if reasons else "No deviation signals detected"
     return {"score": score, "justification": justification}
 
 

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -276,6 +276,23 @@ class TestCorrectnessHeuristic(unittest.TestCase):
         result = score.analyze_dimension("correctness", lines, {}, [])
         self.assertGreaterEqual(result["score"], 9)
 
+    def test_no_receipt_caps_correctness_below_perfect(self) -> None:
+        # Anti-gaming: a transcript that merely avoids error words, with no
+        # executed-check receipt anywhere, must NOT earn a perfect 10. Heuristic
+        # correctness cannot confirm functional correctness without evidence.
+        lines = _make_lines("I refactored the helper and it reads cleanly.\n" * 100)
+        result = score.analyze_dimension("correctness", lines, {}, [])
+        self.assertEqual(result["score"], 9)
+
+    def test_receipt_allows_perfect_correctness(self) -> None:
+        # With a real execution receipt and no error/claim signals, 10 is earned.
+        lines = _make_lines(
+            "$ pytest\n5 passed in 0.3s\n"
+            + "Refactored the helper.\n" * 100
+        )
+        result = score.analyze_dimension("correctness", lines, {}, [])
+        self.assertEqual(result["score"], 10)
+
     def test_many_errors_scores_lower(self) -> None:
         lines = _make_lines(
             "error: compilation failed\n" * 20
@@ -468,11 +485,21 @@ class TestAdherenceHeuristic(unittest.TestCase):
     """Adherence dimension: deviation signals and rubric presence."""
 
     def test_clean_transcript_with_rubric(self) -> None:
+        # A rubric being *available* is context, not compliance — it no longer
+        # adds an unearned point. Baseline 8 with no deviation signals.
         lines = _make_lines("Followed all instructions perfectly.\n" * 100)
         rubric_criteria = {"correctness": "must be correct"}
         result = score.analyze_dimension("adherence", lines, rubric_criteria, [])
-        # Base 8, +1 for rubric criteria = 9
-        self.assertGreaterEqual(result["score"], 9)
+        self.assertEqual(result["score"], 8)
+
+    def test_rubric_presence_does_not_inflate_adherence(self) -> None:
+        # Anti-gaming: identical behaviour scores identically whether or not a
+        # rubric is loaded. Adherence credit is earned by behaviour, not granted
+        # by context. (Pre-fix this returned 9 with a rubric vs 8 without.)
+        lines = _make_lines("Did the work as described.\n" * 100)
+        with_rubric = score.analyze_dimension("adherence", lines, {"correctness": "x"}, [])
+        without_rubric = score.analyze_dimension("adherence", lines, {}, [])
+        self.assertEqual(with_rubric["score"], without_rubric["score"])
 
     def test_deviation_signals_reduce_score(self) -> None:
         lines = _make_lines(


### PR DESCRIPTION
## Summary
Two scoring heuristics handed out unearned credit, making the composite trivially gameable:

- **Adherence** added `+1` whenever a rubric was merely *loaded* — i.e. on every run — inflating it to 9 regardless of behaviour. A run that ignored every instruction but avoided the deviation keywords still scored 9/10 (its own justification said "rubric available", not "complied"). The `+1` is removed: heuristic adherence now reports *deviation* only; positive compliance is scored against the rubric by the opt-in LLM tier.
- **Correctness** returned a free 10 for any transcript that simply avoided the words `error`/`failed`/`exception`. A perfect 10 now requires an **execution receipt** (a test run / exit code — the same artefact `detect_unverified_success` looks for). Without one, the top mark is capped at 9. Legitimately untestable tasks still reach 9.

No new config surface; the correctness cap only ever turns a 10 into a 9 (zero blast radius on already-docked scores).

## Test Plan
- Added 4 anti-gaming tests: rubric presence is score-neutral; identical behaviour scores identically with/without a rubric; a receipt-less clean transcript caps correctness at 9; a receipt earns 10.
- `python3 -m unittest discover tests/` → **650 passed**.
- `python3 scripts/benchmark_pack.py` → **7/7 green**, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)