### PR TITLE
chore: rebrand Verdict to Proofloop (v3.0.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "verdict",
+  "name": "proofloop",
   "owner": {
     "name": "Sattyam Jain",
     "email": "sattyamjain96@gmail.com"
@@ -9,15 +9,15 @@
   },
   "plugins": [
     {
-      "name": "verdict",
+      "name": "proofloop",
       "source": "./",
       "description": "Auto-evaluates skill and agent execution quality with 7-dimension scoring, configurable rubrics, and dual-mode operation.",
-      "version": "2.0.8",
+      "version": "3.0.0",
       "category": "quality-assurance",
       "tags": ["judge", "evaluation", "quality", "scoring", "LLM-as-judge"],
       "license": "MIT",
-      "homepage": "https://github.com/sattyamjjain/verdict",
-      "repository": "https://github.com/sattyamjjain/verdict"
+      "homepage": "https://github.com/sattyamjjain/proofloop",
+      "repository": "https://github.com/sattyamjjain/proofloop"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,15 +1,15 @@
 {
-  "name": "verdict",
-  "version": "2.0.8",
-  "displayName": "Verdict — Universal Skill & Agent Quality Judge",
+  "name": "proofloop",
+  "version": "3.0.0",
+  "displayName": "Proofloop — Universal Skill & Agent Quality Judge",
   "description": "The first universal judge for Claude Code & Cowork. Auto-evaluates skill and agent execution quality with 7-dimension scoring, configurable rubrics, and dual-mode operation (auto hooks + manual /judge command).",
   "author": {
     "name": "Sattyam Jain",
     "email": "sattyamjain96@gmail.com"
   },
   "license": "MIT",
-  "homepage": "https://github.com/sattyamjjain/verdict",
-  "repository": "https://github.com/sattyamjjain/verdict",
+  "homepage": "https://github.com/sattyamjjain/proofloop",
+  "repository": "https://github.com/sattyamjjain/proofloop",
   "platforms": ["claude-code", "claude-cowork"],
   "components": {
     "skills": ["./skills/judge/SKILL.md"],

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report a defect in Verdict's behavior
+description: Report a defect in Proofloop's behavior
 title: "[bug] "
 labels: ["bug"]
 body:
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Which v4.3 surface does this touch?
       description: |
-        Verdict's plugin scope per CLAUDE.md §v4.3 Scope Contract.
+        Proofloop's plugin scope per CLAUDE.md §v4.3 Scope Contract.
         Anything outside these is out-of-scope and belongs in
         Discussions, not Issues.
       options:
@@ -30,7 +30,7 @@ body:
   - type: input
     id: version
     attributes:
-      label: Verdict version
+      label: Proofloop version
       description: |
         Output of `cat .claude-plugin/plugin.json | grep version` in
         an installed copy, or the tag of the release you installed.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,14 @@
 blank_issues_enabled: false
 contact_links:
   - name: Out-of-scope idea / new rubric proposal
-    url: https://github.com/sattyamjjain/verdict/discussions
+    url: https://github.com/sattyamjjain/proofloop/discussions
     about: |
-      Verdict is a Claude Code / Cowork plugin only. New rubrics that
+      Proofloop is a Claude Code / Cowork plugin only. New rubrics that
       target frontier-lab eval benches (SWE-bench, Terminal-Bench,
       GAIA, OSWorld, MCP attack benches, EU AI Act, etc.) are
       out-of-scope per the v4.3 Scope Contract (see CLAUDE.md).
       File those in Discussions instead — that's where they get
       community-aired without polluting the issue tracker.
   - name: Question / how do I use this?
-    url: https://github.com/sattyamjjain/verdict/discussions/categories/q-a
+    url: https://github.com/sattyamjjain/proofloop/discussions/categories/q-a
     about: Open-ended usage questions belong in Discussions Q&A.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,17 +1,17 @@
 name: Feature request
-description: Propose a change to Verdict's plugin behavior
+description: Propose a change to Proofloop's plugin behavior
 title: "[feat] "
 labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        Before filing: read CLAUDE.md §v4.3 Scope Contract. Verdict
+        Before filing: read CLAUDE.md §v4.3 Scope Contract. Proofloop
         is a Claude Code / Cowork plugin only. New rubrics targeting
         frontier-lab eval benches (SWE-bench, Terminal-Bench, GAIA,
         OSWorld, MCP attack benches, EU AI Act, etc.) are
         out-of-scope and should be filed in
-        [Discussions](https://github.com/sattyamjjain/verdict/discussions)
+        [Discussions](https://github.com/sattyamjjain/proofloop/discussions)
         instead.
 
   - type: dropdown

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,7 +41,7 @@ jobs:
           <html lang="en">
           <head>
             <meta charset="utf-8" />
-            <title>Verdict schema registry</title>
+            <title>Proofloop schema registry</title>
             <style>
               body { font-family: -apple-system, system-ui, sans-serif; max-width: 42rem; margin: 3rem auto; padding: 0 1.25rem; color: #1a1a1a; }
               h1 { margin: 0 0 0.25rem; font-size: 1.25rem; }
@@ -54,8 +54,8 @@ jobs:
             </style>
           </head>
           <body>
-            <h1>Verdict schema registry</h1>
-            <p class="tagline">Canonical JSON schemas for scorecards emitted by <a href="https://github.com/sattyamjjain/verdict">sattyamjjain/verdict</a>. See <a href="https://github.com/sattyamjjain/verdict/blob/main/docs/schema-registry.md">docs/schema-registry.md</a> for the stability contract.</p>
+            <h1>Proofloop schema registry</h1>
+            <p class="tagline">Canonical JSON schemas for scorecards emitted by <a href="https://github.com/sattyamjjain/proofloop">sattyamjjain/proofloop</a>. See <a href="https://github.com/sattyamjjain/proofloop/blob/main/docs/schema-registry.md">docs/schema-registry.md</a> for the stability contract.</p>
             <table>
               <thead><tr><th>Schema</th><th>Version</th><th>URL</th></tr></thead>
               <tbody>

--- a/.github/workflows/self-score.yml
+++ b/.github/workflows/self-score.yml
@@ -1,7 +1,7 @@
 name: Self-score
 
 # Dogfooding gate. Treat the PR title + body + changed-files list as a
-# synthetic transcript and run Verdict's own heuristic pass on it. Fail
+# synthetic transcript and run Proofloop's own heuristic pass on it. Fail
 # when the composite drops below the threshold (default 7.0). The
 # scorecard is posted as a PR comment so reviewers see the signal
 # alongside test + marketplace validator output.
@@ -41,7 +41,7 @@ jobs:
 
       - name: Declare sandbox capabilities
         # Claude Code v2.1.117 (Apr 2026) hardened its runtime sandbox.
-        # CI workflows that run Verdict under that sandbox declare the
+        # CI workflows that run Proofloop under that sandbox declare the
         # caps they intend to use via CLAUDE_SANDBOX_CAPS so the
         # workflow stays in sync with the runtime's expectations. The
         # check below is a declaration-only verification — actual
@@ -85,7 +85,7 @@ jobs:
           echo "Generated transcript (${TRANSCRIPT}):"
           head -40 "${TRANSCRIPT}"
 
-      - name: Run Verdict self-score
+      - name: Run Proofloop self-score
         id: score
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,6 +349,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   BrowseComp-Plus (2026-05-06), Managed Agents Outcomes rubric
   beta (2026-05-09).
 
+## [3.0.0] - 2026-06-13
+
+### Changed
+
+- **Renamed the project to Proofloop.** The plugin name, schema
+  namespace, and all user-facing surfaces move from "Verdict" to
+  "Proofloop"; the GitHub repository is now `sattyamjjain/proofloop`
+  (old URLs redirect). The rename resolves a hard collision with Haize
+  Labs' open-source `verdict` LLM-judge library (PyPI `verdict`,
+  verdict.haizelabs.com) in the identical category. The scorecard
+  schema `$id` moves to `https://proofloop.dev/schemas/scorecard.v1.json`;
+  the on-disk shape is unchanged (still `scorecard.v1`, additive
+  contract intact). Historical CHANGELOG and release notes keep the
+  "Verdict" name they shipped under.
+
+### Fixed
+
+- **Hardened two gameable scoring heuristics** (originally PR #43):
+  - *Adherence* no longer adds +1 just because a rubric was loaded — it
+    did so on every run, inflating adherence to 9 regardless of
+    behaviour. The heuristic tier now reports deviation only; positive
+    compliance is scored against the rubric by the opt-in LLM tier.
+  - *Correctness* no longer returns a free 10 for a transcript that
+    merely avoids the words "error"/"failed"/"exception". A perfect
+    score now requires an execution receipt (a test run / exit code);
+    without one the top mark is capped at 9. Untestable tasks still
+    reach 9. Adds 4 anti-gaming tests.
+
 ## [2.0.8] - 2026-06-13
 
 Patch release. Adds a stdlib-only, offline **unverified-success
@@ -1428,7 +1456,7 @@ surface.
   `python3 skills/judge/scripts/explain.py --scorecard <PATH>
   [--format md|json] [--out PATH]`. Slash command updated:
   `/judge --explain <SCORECARD>`. Source signal:
-  [Discussions #43](https://github.com/sattyamjjain/verdict/discussions/43).
+  [Discussions #43](https://github.com/sattyamjjain/proofloop/discussions/43).
 - **OWASP MCP Top 10 (beta) coverage rubric**
   (`skills/judge/rubrics/owasp-mcp-top-10-beta.md` +
   `.weights.json`). Maps MCP01–MCP10 risks to Verdict's canonical

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 <!-- MANUAL: project-description -->
 ## Overview
 
-**Verdict** is a Claude Code plugin that auto-evaluates skill and agent execution quality. It provides 7-dimension scoring (correctness, completeness, adherence, actionability, efficiency, safety, consistency), configurable rubrics, persistent scorecards, and dual-mode operation (auto via hooks + manual via `/judge` command). Works on both Claude Code and Claude Cowork.
+**Proofloop** is a Claude Code plugin that auto-evaluates skill and agent execution quality. It provides 7-dimension scoring (correctness, completeness, adherence, actionability, efficiency, safety, consistency), configurable rubrics, persistent scorecards, and dual-mode operation (auto via hooks + manual via `/judge` command). Works on both Claude Code and Claude Cowork.
 
 - Author: Sattyam Jain
 - License: MIT
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 <!-- MANUAL: v43-scope-contract -->
 ## v4.3 Scope Contract (2026-05-03)
 
-Verdict is a **Claude Code / Cowork plugin only.** Per the 2026-05-03 v4.3 scope reset (runbook §scope-reset), the rubric and adapter inventory is pinned to plugin-domain quality scoring. Frontier-lab eval-bench scope (SWE-bench, Terminal-Bench, GAIA, OSWorld, MCP attack benches, etc.) is explicitly out of scope and will not be re-added without a runbook spec change.
+Proofloop is a **Claude Code / Cowork plugin only.** Per the 2026-05-03 v4.3 scope reset (runbook §scope-reset), the rubric and adapter inventory is pinned to plugin-domain quality scoring. Frontier-lab eval-bench scope (SWE-bench, Terminal-Bench, GAIA, OSWorld, MCP attack benches, etc.) is explicitly out of scope and will not be re-added without a runbook spec change.
 
 **In-scope rubrics (11):** `code-review`, `security`, `devops`, `data-analysis`, `frontend-design`, `testing`, `documentation`, `content-writing`, `research`, `default`, `custom-template`.
 
@@ -70,7 +70,7 @@ This project has no build step or package manager. Python scripts use stdlib onl
 ## Architecture
 
 ```
-Verdict/  (v2.0.2)
+Proofloop/  (v2.0.2)
 ├── .claude-plugin/
 │   ├── plugin.json              # Plugin manifest (skills, agents, commands, hooks)
 │   └── marketplace.json         # Marketplace listing metadata

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,7 @@
 ## Our pledge
 
 We as members, contributors, and leaders pledge to make participation
-in the Verdict community a harassment-free experience for everyone,
+in the Proofloop community a harassment-free experience for everyone,
 regardless of age, body size, visible or invisible disability,
 ethnicity, sex characteristics, gender identity and expression, level
 of experience, education, socio-economic status, nationality, personal

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Verdict
+# Contributing to Proofloop
 
-Verdict welcomes contributions. The most impactful kinds, in order:
+Proofloop welcomes contributions. The most impactful kinds, in order:
 
 1. **Rubrics** for domains we don't cover (`security-scan-v2`,
    `kubernetes-review`, `sql-review`, `pentest`, …).
@@ -33,8 +33,8 @@ hard constraint — see the bottom of this file.
 No dependencies beyond stdlib:
 
 ```shell
-git clone https://github.com/sattyamjjain/verdict
-cd verdict
+git clone https://github.com/sattyamjjain/proofloop
+cd proofloop
 python3 -m unittest discover tests/ -v       # full suite
 python3 scripts/validate_marketplace.py      # schema check
 python3 scripts/benchmark_pack.py            # regression gate
@@ -124,7 +124,7 @@ notifications sometimes slip through.
 
 ## The stdlib-only rule
 
-Verdict's install story is "zero ongoing cost, no supply-chain risk,
+Proofloop's install story is "zero ongoing cost, no supply-chain risk,
 `pip install` is instant." Every third-party dep weakens that pitch.
 If you think you need one, open an issue instead of a PR — we'll
 discuss whether the feature can be reshaped to stay stdlib-only, or

--- a/DEEP_ANALYSIS.md
+++ b/DEEP_ANALYSIS.md
@@ -1,6 +1,6 @@
-# Verdict — Deep Codebase Analysis
+# Proofloop — Deep Codebase Analysis
 
-**Plugin:** Verdict — Universal Skill & Agent Quality Judge
+**Plugin:** Proofloop — Universal Skill & Agent Quality Judge
 **Version:** 1.0.0 (released 2026-02-13)
 **Stack:** Python 3.9+ stdlib-only · bash (hooks) · markdown rubrics · `unittest`
 **Platforms:** `claude-code`, `claude-cowork`
@@ -10,7 +10,7 @@
 
 ## 1. Executive summary
 
-Verdict is a Claude Code / Cowork plugin that scores skill or subagent execution transcripts along seven weighted dimensions — correctness, completeness, adherence, actionability, efficiency, safety, consistency — then renders a scorecard, persists it as JSON, and optionally blocks the workflow (hook exit code 2) when the composite falls below a configurable threshold.
+Proofloop is a Claude Code / Cowork plugin that scores skill or subagent execution transcripts along seven weighted dimensions — correctness, completeness, adherence, actionability, efficiency, safety, consistency — then renders a scorecard, persists it as JSON, and optionally blocks the workflow (hook exit code 2) when the composite falls below a configurable threshold.
 
 The codebase is **unusually disciplined for a plugin**: ~2,400 lines of Python across three scripts, 132 unit tests (all passing), 10 domain-specific rubrics plus a documented `custom-template.md`, and bash hooks with proper dependency checks. The scoring engine is deterministic, stdlib-only (no `pip` dependencies), and the output JSON schema is well-specified.
 
@@ -21,16 +21,16 @@ The product risk sits almost entirely in the **analyzer heuristics themselves**.
 - Legitimate use of `os.getenv('PASSWORD')` sometimes trips the "safety" credential detector.
 - Short, correct answers to short questions are penalized by a length-as-proxy-for-completeness rule.
 
-These are tuning problems, not structural ones — but they cap the tool's accuracy well below LLM-based judges. The natural next step is to make Verdict the *structure* (rubric resolution, persistence, hooks, rendering) and plug a model-based analyzer behind the heuristics.
+These are tuning problems, not structural ones — but they cap the tool's accuracy well below LLM-based judges. The natural next step is to make Proofloop the *structure* (rubric resolution, persistence, hooks, rendering) and plug a model-based analyzer behind the heuristics.
 
 ---
 
 ## 2. Repository layout
 
 ```
-Verdict/
+Proofloop/
 ├── .claude-plugin/
-│   ├── plugin.json                Manifest (name=verdict, v1.0.0, 2 platforms)
+│   ├── plugin.json                Manifest (name=proofloop, v1.0.0, 2 platforms)
 │   └── marketplace.json           Marketplace listing
 ├── judge-config.json              Root config (auto-judge, weights, threshold)
 ├── README.md, CHANGELOG.md, CLAUDE.md, LICENSE (MIT)
@@ -67,7 +67,7 @@ Verdict/
 ## 3. Plugin manifest
 
 `.claude-plugin/plugin.json`:
-- `name: "verdict"`, `version: "1.0.0"`, `license: "MIT"`
+- `name: "proofloop"`, `version: "1.0.0"`, `license: "MIT"`
 - `platforms: ["claude-code", "claude-cowork"]` — dual-platform
 - Components registered: 1 skill (`skills/judge/SKILL.md`), 1 agent (`agents/judge-agent.md`), 4 slash commands, hooks JSON, and the root `judge-config.json`.
 
@@ -167,7 +167,7 @@ Four patterns tried in order, first match wins:
 3. JSON field `"skill": "<name>"`
 4. Leading slash-command invocation `/<name>` on first line
 
-Caveats: Pattern 4 will incorrectly fire on `/judge` itself (i.e. Verdict can detect its own command as the "skill" being judged). Pattern 1 takes whatever appears last in the transcript if multiple skills are referenced. Skill names with dots (`skill.name`) aren't matched by the `[a-zA-Z0-9_-]+` class.
+Caveats: Pattern 4 will incorrectly fire on `/judge` itself (i.e. Proofloop can detect its own command as the "skill" being judged). Pattern 1 takes whatever appears last in the transcript if multiple skills are referenced. Skill names with dots (`skill.name`) aren't matched by the `[a-zA-Z0-9_-]+` class.
 
 ---
 
@@ -223,7 +223,7 @@ Rubric parsing uses `### DimensionName` headings; non-standard heading formats (
 6. Read back composite, grade, one-liner.
 7. **If composite < threshold: exit 2** (signals "block") — otherwise emit a success payload on stdout and exit 0.
 
-Exit-code semantics match Verdict's claim ("exit 2 is blocking"), but effective blocking depends on whether the host (Claude Code / Cowork) honors exit 2 from Stop-event hooks, which varies by host version. Worth documenting in the README.
+Exit-code semantics match Proofloop's claim ("exit 2 is blocking"), but effective blocking depends on whether the host (Claude Code / Cowork) honors exit 2 from Stop-event hooks, which varies by host version. Worth documenting in the README.
 
 ---
 
@@ -290,14 +290,14 @@ Coverage by category:
 4. **Credential context fragile.** `os.getenv('PASSWORD')` often correctly avoids the penalty, but the regex skip-list (`env|os.environ|getenv|config`) misses `settings.get('PASSWORD')` and similar. Fix: AST-parse Python blocks when possible; for other languages, require a literal on the right-hand side (`= '…'`) before docking points.
 5. **Rubric weight override isn't supported.** `judge-config.json` holds one set of weights globally; a testing skill that should weight "completeness" higher (edge cases) or a security skill that should weight "safety" higher can't. Fix: allow per-rubric weight overrides in YAML frontmatter or a sibling `.weights.json`.
 6. **Config weight-sum not enforced.** See §10.
-7. **`/judge` skill-detection self-match.** Pattern 4 will score Verdict's own commands as the "skill" being judged. Fix: exclude a known allow-list of Verdict commands from that pattern.
+7. **`/judge` skill-detection self-match.** Pattern 4 will score Proofloop's own commands as the "skill" being judged. Fix: exclude a known allow-list of Proofloop commands from that pattern.
 8. **Rubric drift.** Rubrics are static markdown; no versioning, no expiry. Consider adding a `rubric_version` field so `score.py` can record which rubric version produced each score.
 
 ---
 
 ## 13. Bottom line
 
-Verdict is a **tight, principled starting point** for plugin-based quality evaluation on Claude Code and Cowork. Its strengths — zero-dependency Python, a strong test suite, well-structured domain rubrics, dual-mode (auto + manual), and persistent JSON scorecards — are exactly right for a v1.0 release. The next release should treat the regex analyzers as a *fallback* behind an optional LLM judge and address the length-as-proxy and neutral-baseline biases. Once those are fixed, Verdict can credibly claim the "universal" in its tagline.
+Proofloop is a **tight, principled starting point** for plugin-based quality evaluation on Claude Code and Cowork. Its strengths — zero-dependency Python, a strong test suite, well-structured domain rubrics, dual-mode (auto + manual), and persistent JSON scorecards — are exactly right for a v1.0 release. The next release should treat the regex analyzers as a *fallback* behind an optional LLM judge and address the length-as-proxy and neutral-baseline biases. Once those are fixed, Proofloop can credibly claim the "universal" in its tagline.
 
 ---
 
@@ -312,9 +312,9 @@ in `tests/fixtures/scorecards/` via `tests/test_schema.py`.
 
 ### Identifiers
 
-- `$schema`: `https://verdict.dev/schemas/scorecard.v1.json` — stable
+- `$schema`: `https://proofloop.dev/schemas/scorecard.v1.json` — stable
   URI that never changes for the v1 line of the schema. The domain will
-  resolve to a static copy of the schema once `verdict.dev` is live; until
+  resolve to a static copy of the schema once `proofloop.dev` is live; until
   then the URI is a logical identifier and the authoritative copy is the
   file in-repo.
 - `schemaVersion`: SemVer string `"MAJOR.MINOR.PATCH"`.
@@ -353,7 +353,7 @@ to the legacy field when parsing older documents.
 
 ### Consumer pinning
 
-Downstream tools (including Verdict Studio, `benchmark_pack.py`, and
+Downstream tools (including Proofloop Studio, `benchmark_pack.py`, and
 external dashboards) should parse `schemaVersion` first. The minimum
 compatible pin is `>= 1.0.0, < 2.0.0`. Any tool that needs a v1.1+
 field should guard on `schemaVersion` and degrade gracefully for

--- a/INSTALL-COWORK.md
+++ b/INSTALL-COWORK.md
@@ -1,6 +1,6 @@
-# Installing Verdict on Claude Cowork
+# Installing Proofloop on Claude Cowork
 
-Verdict ships as a dual-platform plugin (`claude-code` + `claude-cowork`).
+Proofloop ships as a dual-platform plugin (`claude-code` + `claude-cowork`).
 The standard marketplace install flow works on both platforms, but Cowork
 currently has an open plugin-loading issue that affects some
 organizations. This guide covers the canonical path and the workaround.
@@ -8,8 +8,8 @@ organizations. This guide covers the canonical path and the workaround.
 ## Recommended: marketplace install
 
 ```shell
-/plugin marketplace add sattyamjjain/verdict
-/plugin install verdict@verdict
+/plugin marketplace add sattyamjjain/proofloop
+/plugin install proofloop@proofloop
 ```
 
 This clones the repo into Cowork's plugin cache, wires up the Stop /
@@ -35,8 +35,8 @@ Until it lands, use the zip-upload path:
 
    ```shell
    gh release download v1.1.0 \
-     --repo sattyamjjain/verdict \
-     --pattern 'verdict-*.zip'
+     --repo sattyamjjain/proofloop \
+     --pattern 'proofloop-*.zip'
    ```
 
 2. In Cowork → **Settings** → **Plugins** → **Upload**, select the
@@ -49,11 +49,11 @@ Until it lands, use the zip-upload path:
 ## Verifying installation
 
 After install, run any skill that is on the `always` list (e.g.
-`/code-review`). When the turn ends, Verdict posts a single-line
+`/code-review`). When the turn ends, Proofloop posts a single-line
 scorecard via the Stop hook:
 
 ```
-Verdict: code-review → 8.7/10 (A-). Solid execution with minor areas
+Proofloop: code-review → 8.7/10 (A-). Solid execution with minor areas
 for improvement.
 ```
 
@@ -72,8 +72,8 @@ If no line appears:
 ## Uninstalling
 
 ```shell
-/plugin uninstall verdict@verdict
-/plugin marketplace remove verdict
+/plugin uninstall proofloop@proofloop
+/plugin marketplace remove proofloop
 ```
 
 Score history in `skills/judge/scores/` is not deleted automatically —
@@ -84,7 +84,7 @@ to render trends after reinstalling.
 
 Routines-driven scoring is supported on all Cowork plans that include
 Claude Code on the web. Each Routine run is a normal Claude Code
-session: the routine prompt is the user turn, and Verdict's Stop hook
+session: the routine prompt is the user turn, and Proofloop's Stop hook
 fires at the end exactly as it would in an interactive session. No
 `--mode routine` flag is required — the routine prompt is visible to
-Verdict through the normal transcript.
+Proofloop through the normal transcript.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -89,12 +89,12 @@ format without touching the network.
 
 - `code-review-aider-polyglot.md` — maps Aider-polyglot benchmark
   axes (syntactic/semantic correctness, multi-file coherence,
-  instruction-follow, diff compaction) onto Verdict's canonical
+  instruction-follow, diff compaction) onto Proofloop's canonical
   seven dimensions.
 - `skill-compliance.md` — MLflow's "skill compliance" dimension
   (did the agent actually load and follow the skill?) ported offline.
 - `model-spec-compliance.md` — OpenAI Model Spec Evals 1-7 scale,
-  with a documented rescaling table to Verdict's native 1-10.
+  with a documented rescaling table to Proofloop's native 1-10.
 
 Each carries a `source_signal:` header citing the article it rides.
 `tests/test_rubric_packs.py` (6 cases) exercises structure + parser +
@@ -102,7 +102,7 @@ end-to-end scoring.
 
 #### N4 — `--export openai-evals` exporter
 
-`skills/judge/exporters/openai_evals.py` converts a Verdict scorecard
+`skills/judge/exporters/openai_evals.py` converts a Proofloop scorecard
 into Model Spec Evals JSON (`{run_id, criteria, summary}`). Threshold
 7/10 default. `--export-rescale` flag emits Model Spec's native 1-7
 bucket. LLM second-opinion fields round-trip into `llm_score` /
@@ -114,7 +114,7 @@ bucket. LLM second-opinion fields round-trip into `llm_score` /
 `skills/judge/integrations/lighteval_shim.py` exposes
 `verdict_metric(predictions, references, rubric)` returning a float in
 `[0, 1]`. `lighteval` is **never** imported at runtime — lazy-import
-protocol preserves Verdict's offline-first pitch.
+protocol preserves Proofloop's offline-first pitch.
 `tests/test_lighteval_shim.py` (7 cases).
 
 #### N6 — MLflow trace ingestion adapter
@@ -130,7 +130,7 @@ Fixture at `tests/fixtures/mlflow-trace.json`.
 
 `docs/schema-registry.md` + `.github/workflows/pages.yml`. Every file
 under `schemas/` mirrors to GitHub Pages on push to `main`; once
-`verdict.dev` is live, a CNAME swap lands the canonical URLs.
+`proofloop.dev` is live, a CNAME swap lands the canonical URLs.
 
 #### N8 — `/judge --compare-runs` (and `/compare` slash command)
 
@@ -152,7 +152,7 @@ can gate. Complement to `/judge --against HEAD~1`.
 
 - Offline-first preserved: LLM judge default **off**, MLflow adapter
   **parse-only** (never imports `mlflow`), LightEval shim **lazy-imports**.
-- No new non-stdlib runtime deps in Verdict core.
+- No new non-stdlib runtime deps in Proofloop core.
 - No secrets in fixtures.
 - 384 / 314 / 237 — test count never dropped below baseline at any
   intermediate commit.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Verdict
+# Proofloop
 
-[![CI](https://github.com/sattyamjjain/verdict/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/sattyamjjain/verdict/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/sattyamjjain/verdict)](https://github.com/sattyamjjain/verdict/releases/latest)
+[![CI](https://github.com/sattyamjjain/proofloop/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/sattyamjjain/proofloop/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/sattyamjjain/proofloop)](https://github.com/sattyamjjain/proofloop/releases/latest)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 **Auto-grade every Claude Code and Cowork skill execution on seven
@@ -9,7 +9,7 @@ dimensions. No LLM call. No config. Just a scorecard.**
 
 Every other evaluation tool in this space (Braintrust, Langfuse,
 Phoenix, Helicone, Promptfoo, DeepEval, Ragas, LangSmith, Opik)
-requires a second LLM to grade the first. Verdict runs offline regex
+requires a second LLM to grade the first. Proofloop runs offline regex
 heuristics inside the editor. Zero ongoing cost, zero API key, zero
 network call — it ships as a Claude Code plugin that fires on every
 `Stop` and `SubagentStop` event.
@@ -19,8 +19,8 @@ network call — it ships as a Claude Code plugin that fires on every
 ## Install
 
 ```shell
-/plugin marketplace add sattyamjjain/verdict
-/plugin install verdict@verdict
+/plugin marketplace add sattyamjjain/proofloop
+/plugin install proofloop@proofloop
 ```
 
 That's it. The next skill or subagent execution that matches an
@@ -33,9 +33,9 @@ workaround (GH #39400), see [INSTALL-COWORK.md](INSTALL-COWORK.md).
 
 ---
 
-## Why Verdict
+## Why Proofloop
 
-|                            | Verdict | Braintrust / Langfuse / Phoenix | Promptfoo / DeepEval | LangSmith / Opik |
+|                            | Proofloop | Braintrust / Langfuse / Phoenix | Promptfoo / DeepEval | LangSmith / Opik |
 | -------------------------- | :-----: | :-----------------------------: | :------------------: | :--------------: |
 | Runs inside Claude Code    | ✓       | ✗                               | ✗                    | ✗                |
 | Offline (no LLM call)      | ✓       | ✗                               | optional             | ✗                |
@@ -85,7 +85,7 @@ workaround (GH #39400), see [INSTALL-COWORK.md](INSTALL-COWORK.md).
   [§Benchmark hygiene lint](#benchmark-hygiene-lint-aba-anchored)
   below.
 - **Same-family judge guard.** When the opt-in LLM second opinion is
-  enabled, Verdict checks whether the judge model shares a vendor
+  enabled, Proofloop checks whether the judge model shares a vendor
   family with the model that produced the transcript. A match sets
   `self_preference_risk: true` and warns on the console (Claude judging
   Claude inflates scores); a configured cross-family judge is
@@ -100,7 +100,7 @@ workaround (GH #39400), see [INSTALL-COWORK.md](INSTALL-COWORK.md).
 - **Stdlib only.** Python 3.9+, no third-party packages, installs
   instantly with zero supply-chain risk.
 
-> **v1.x → v2.0.0 migration.** v2.0.0 trimmed Verdict to its plugin
+> **v1.x → v2.0.0 migration.** v2.0.0 trimmed Proofloop to its plugin
 > scope per the 2026-05-03 v4.3 reset: 16 frontier-lab eval-bench
 > rubrics, 6 cross-ecosystem adapters, and 7 bench-eval scripts were
 > removed. If you depended on `swe-bench-pro`, `terminal-bench`,
@@ -119,7 +119,7 @@ Skills on the `auto_judge.always` allowlist are scored without user
 intervention. The `Stop` hook emits:
 
 ```
-Verdict: code-review → 8.7/10 (A-). Solid execution with minor areas for improvement.
+Proofloop: code-review → 8.7/10 (A-). Solid execution with minor areas for improvement.
 ```
 
 ### Manual mode
@@ -154,8 +154,8 @@ python3 skills/judge/scripts/score.py --adapter openai-compatible ...
 ```shell
 python3 skills/judge/scripts/studio.py \
   --scores-dir skills/judge/scores \
-  --output verdict-studio.html
-open verdict-studio.html
+  --output proofloop-studio.html
+open proofloop-studio.html
 ```
 
 ### Explain a scorecard for a PR comment
@@ -214,7 +214,7 @@ was actually executed (a runner invocation, a test count, an exit
 code). Claiming a pass without running it is fabricated success, a
 correctness/honesty failure, so `detect_unverified_success` docks the
 **correctness** dimension and adds a red flag — the same dual treatment
-Verdict already gives a hallucinated fact. The offending claim and a
+Proofloop already gives a hallucinated fact. The offending claim and a
 one-line remediation surface in a top-level `unverified_success` array.
 Configurable via `judge-config.json.unverified_success`
 (`enabled` / `correctness_dock` / `red_flag`).
@@ -348,7 +348,7 @@ shellcheck hooks/*.sh                         # hook-script lint
 before any score is consumed. It adapts the four issue classes from
 [arXiv:2605.26079](https://arxiv.org/abs/2605.26079) (Wang et al.
 2026, *Automated Benchmark Auditing for AI Agents and Large
-Language Models*, v1 2026-05-25) to Verdict's transcript-regression
+Language Models*, v1 2026-05-25) to Proofloop's transcript-regression
 shape. ABA found that **25.7% of tasks across 168 benchmarks**
 contained one of these issues, and that removing them moved model
 scores by ~9.6–9.9% — i.e., suspect bench plumbing changes the
@@ -387,13 +387,13 @@ the moat; defaulting to LLM judging would push the trust boundary
 into a token-billed black box, which is exactly what we lint
 against).
 
-**Scope honesty.** Verdict's "benchmark pack" scores transcripts
+**Scope honesty.** Proofloop's "benchmark pack" scores transcripts
 against expected score bounds, not tasks against ground-truth
 outputs (`benchmarks/manifest.json` is explicitly *not* a public
 eval bench — see `benchmarks/README.md`). The four ABA classes
 therefore apply *by analogy*, mapped to the regression-gate shape;
 the rule descriptions above and the lint's own help text make this
-adaptation explicit. If Verdict ever grows a true task benchmark,
+adaptation explicit. If Proofloop ever grows a true task benchmark,
 the rules will need a literal pass — tracked as **O17** in
 `CHANGELOG.md`.
 
@@ -439,10 +439,10 @@ jq '.verifier_collapse.gate_mode = "fail"' judge-config.json > tmp && mv tmp jud
 
 The `judge-on-stop.sh` ship-gate honours `gate_mode` ∈
 `{"warn", "fail", "off"}` and emits
-`Verdict {WARNING,BLOCKED}: verifier collapse detected for <skill>`
+`Proofloop {WARNING,BLOCKED}: verifier collapse detected for <skill>`
 on stderr.
 
-**Anchor.** The signal is derived from Verdict's own consistency
+**Anchor.** The signal is derived from Proofloop's own consistency
 dimension plus the **Soft-SVeRL** project anchor — distinct from
 variance-based consistency, not a sibling-benchmark analogy. The
 heuristic is offline statistics, default-on, and never calls an
@@ -456,7 +456,7 @@ The opt-in LLM second opinion
 trustworthy as the judge. An LLM judge systematically over-scores
 outputs from its own model family, so when the second-opinion judge
 shares a family with the model that produced the transcript, the score
-is biased upward and Verdict says so.
+is biased upward and Proofloop says so.
 
 Before the call, `same_family_guard` (in
 `skills/judge/analyzers/llm_judge.py`) buckets the executing model
@@ -466,7 +466,7 @@ model into vendor families (`anthropic` / `openai` / `google` /
 
 1. sets `self_preference_risk: true` on the scorecard (mirrored in the
    `same_family_guard` object with both families), and emits
-   `Verdict WARNING: judge and executing model share a family …` on
+   `Proofloop WARNING: judge and executing model share a family …` on
    stderr; and
 2. if `llm_second_opinion.alternate_judge_models` names a cross-family
    judge, **auto-prefers** it for the call (reachable via the injected
@@ -484,7 +484,7 @@ win-rate margins ([arXiv:2306.05685](https://arxiv.org/abs/2306.05685),
 MT-Bench — GPT-4 +10pp, Claude-v1 +25pp self-win-rate), and merely
 re-labelling an output as the judge's own work swings its scores by
 +23–93pp ([arXiv:2606.05976](https://arxiv.org/abs/2606.05976),
-role-relabel). Verdict keeps the judge framed as a third-party
+role-relabel). Proofloop keeps the judge framed as a third-party
 "second-opinion judge" (never first-person), flags the residual
 same-family risk, and prefers a cross-family judge when one is
 configured.
@@ -507,7 +507,7 @@ assistant turn:
 | capitulates **with** a re-derivation / "because …" | legitimate concession | not penalised |
 | holds its answer | held | `score` 1.0 |
 
-That middle row is the point: Verdict **does not penalise a correct
+That middle row is the point: Proofloop **does not penalise a correct
 concession**. Conceding to a *true* user correction — and explaining
 why — is good behaviour; only bare capitulation with no new
 justification is scored as sycophancy. The result rides on the
@@ -535,26 +535,29 @@ Refs: [arXiv:2606.09068](https://arxiv.org/abs/2606.09068),
 ## Roadmap
 
 See [ROADMAP_2026.md](ROADMAP_2026.md) for the 90-day plan. Latest
-release: [v2.0.8](https://github.com/sattyamjjain/verdict/releases/tag/v2.0.8)
-(verifier-collapse detector — flags judges that have flatlined at
-the top of the scale over the rolling scorecard window, docks the
-consistency dim, surfaces in `/judge --explain` + the Stop-hook
-ship-gate; offline stdlib-only, default-on).
+release: [v3.0.0](https://github.com/sattyamjjain/proofloop/releases/tag/v3.0.0)
+(**rebrand to Proofloop** + engine hardening — adherence no longer
+hands out an unearned point for a rubric merely being loaded, and a
+perfect correctness score now requires an execution receipt; offline
+stdlib-only).
 Previous releases:
-[v2.0.3](https://github.com/sattyamjjain/verdict/releases/tag/v2.0.3)
+[v2.0.8](https://github.com/sattyamjjain/proofloop/releases/tag/v2.0.8)
+(verifier-collapse detector — flags judges that have flatlined at the
+top of the scale over the rolling scorecard window),
+[v2.0.3](https://github.com/sattyamjjain/proofloop/releases/tag/v2.0.3)
 (ABA-anchored benchmark hygiene lint + ship-gate wire-up — flags
 spec gaps, env coupling, brittle grading, and missing ground truth
 in the regression-gate manifest *before* its scores ship; SARIF
 output for CI surfacing),
-[v2.0.2](https://github.com/sattyamjjain/verdict/releases/tag/v2.0.2)
+[v2.0.2](https://github.com/sattyamjjain/proofloop/releases/tag/v2.0.2)
 (safety-dim allowlist tracks Claude Code v2.1.126 — `.git/`,
 `.vscode/`, and a closed POSIX/zsh shell-config-file set added to
 `_is_plugin_author_write`),
-[v2.0.1](https://github.com/sattyamjjain/verdict/releases/tag/v2.0.1)
+[v2.0.1](https://github.com/sattyamjjain/proofloop/releases/tag/v2.0.1)
 (opt-in `duration_ms` enrichment + safety `.claude` path
 allowlist + marketplace validator v2.1.120 keys), and the
 breaking
-[v2.0.0](https://github.com/sattyamjjain/verdict/releases/tag/v2.0.0)
+[v2.0.0](https://github.com/sattyamjjain/proofloop/releases/tag/v2.0.0)
 trim to the v4.3 plugin-only scope — see
 [`CHANGELOG.md`](CHANGELOG.md#200---2026-05-03) and the
 [v1.x → v2.0.0 migration note](#features). No open tracker issues —
@@ -565,7 +568,7 @@ cycle starts and closed at release.
 
 Rubric contributions welcome — see `skills/judge/rubrics/custom-template.md`.
 Community rubrics can be installed via `scripts/install_rubric.py`
-from any HTTPS URL that serves a Verdict-shaped rubric.
+from any HTTPS URL that serves a Proofloop-shaped rubric.
 
 ## License
 

--- a/ROADMAP_2026.md
+++ b/ROADMAP_2026.md
@@ -1,4 +1,4 @@
-# Verdict — Roadmap to Top 1% (April 2026)
+# Proofloop — Roadmap to Top 1% (April 2026)
 
 > ⚠️ **Historical document.** Sections below reference frontier-lab
 > rubrics, cross-ecosystem adapters, and bench-eval scripts that
@@ -20,7 +20,7 @@ Read `ECOSYSTEM_STATE_2026-04.md` first.
 
 This is the project with the shortest path to 1 k stars. Research found **no direct competitor** that ships as a Claude Code / Cowork plugin with hook-based auto-scoring + persistent scorecards + offline heuristics + per-domain rubrics. The community `agent-judge` skill is ~150 stars and lacks persistence, hooks, and rubrics. Anthropic has not shipped a first-party scorer. The plugin marketplace ecosystem (2,500+ marketplaces, 9,000+ plugins) is actively searched by the 747 k-member `/r/ClaudeAI` community that has no answer to "how do I measure my skills' quality over time."
 
-**Verdict is first-mover in a visible category.** This is rare.
+**Proofloop is first-mover in a visible category.** This is rare.
 
 **Recommended tagline:** *"Auto-grade every Claude Code and Cowork skill execution on seven dimensions. No LLM call. No config. Just a scorecard."*
 
@@ -37,8 +37,8 @@ The "no LLM call" detail matters more than you think — every competitor (Brain
    - `claudemarketplaces.com`
    - `aitmpl.com`
    - `buildwithclaude.com`
-2. **Support the new `agent` hook event type** — Claude Code 2.1.x added agent hooks (60 s timeout, 50 turns). Verdict today handles `Stop` and `SubagentStop`; add `agent` so Verdict scores tool-using sub-agent invocations too.
-3. **Routines support** — Routines (Apr 14, research preview) fire scheduled prompts without an interactive session. Verdict's hooks must not crash when the transcript lacks a user turn. Add a `--mode routine` flag.
+2. **Support the new `agent` hook event type** — Claude Code 2.1.x added agent hooks (60 s timeout, 50 turns). Proofloop today handles `Stop` and `SubagentStop`; add `agent` so Proofloop scores tool-using sub-agent invocations too.
+3. **Routines support** — Routines (Apr 14, research preview) fire scheduled prompts without an interactive session. Proofloop's hooks must not crash when the transcript lacks a user turn. Add a `--mode routine` flag.
 4. **Opus 4.7 tokenizer** — the new tokenizer shifts token counts up to 35%. Today's efficiency dimension compares raw token counts; update the efficiency analyzer to use model-aware normalization.
 5. **Cowork plugin-loading bug workaround** — document the GH #39400 workaround (zip upload vs marketplace install) prominently in the README.
 6. **The heuristic brittleness issues** from the earlier `DEEP_ANALYSIS.md`:
@@ -50,24 +50,24 @@ The "no LLM call" detail matters more than you think — every competitor (Brain
 ### 2.2 Features that widen the moat
 
 1. **Small judge-model bootstrap option** — ship an **opt-in** path that calls Claude Haiku 4.5 (cheapest frontier model, $1/$5) or the Atla Selene 8B open judge for a second-opinion score. Default is still heuristic/offline; LLM is the premium mode. This covers the "but LLM-as-judge is more accurate" objection without betraying the offline-first positioning.
-2. **Cross-ecosystem scoring** — today Verdict scores Claude Code transcripts. Extend to:
+2. **Cross-ecosystem scoring** — today Proofloop scores Claude Code transcripts. Extend to:
    - **OpenAI Codex** sessions (`.codex/` transcripts or CLI output capture).
    - **Cursor / Windsurf / Continue** agent sessions (via OpenAI-compatible session logs).
    - **Gemini CLI** sessions (new `gemini-cli` session format, v0.38+).
    - **Claude Cowork** session transcripts.
    A single plugin that scores across platforms is unique.
-3. **Agent-airlock OTel input** — consume the OTel audit stream from agent-airlock and score a running agent live, not just post-mortem. Verdict becomes the real-time quality dashboard for your middleware. Cross-repo wedge.
-4. **Verdict Studio** — a local dashboard (single-binary, no server) showing trends, per-skill radar charts, weekly digests, team rollups in Cowork.
+3. **Agent-airlock OTel input** — consume the OTel audit stream from agent-airlock and score a running agent live, not just post-mortem. Proofloop becomes the real-time quality dashboard for your middleware. Cross-repo wedge.
+4. **Proofloop Studio** — a local dashboard (single-binary, no server) showing trends, per-skill radar charts, weekly digests, team rollups in Cowork.
 5. **Per-rubric weight overrides** — today `judge-config.json` has global weights. Allow per-rubric overrides so e.g. the `security` rubric weights safety 0.4 vs the default 0.1.
 6. **Rubric marketplace** — let users publish and fork rubrics. Seeded with your 11 rubrics; aim for 50 community rubrics in 90 days.
-7. **Benchmark pack** — ship a `verdict benchmark` command that runs a curated transcript corpus through the scorer and asserts regressions. Pairs with CI.
+7. **Benchmark pack** — ship a `proofloop benchmark` command that runs a curated transcript corpus through the scorer and asserts regressions. Pairs with CI.
 8. **Regression-aware scoring** — detect when the same skill is executed on a newer model and the score changes significantly. Model-drift detection is underserved (Galileo Luna-2 does this; nobody else at the plugin level).
 9. **`/judge --against commit HEAD~1`** — compare current skill output to the previous run on the same input. Git-native diff-aware scoring.
 10. **Hook for scheduled weekly team digests** in Cowork (pairs with Anthropic Routines).
 
 ### 2.3 Naming and branding
 
-`Verdict` is a good name. Keep it. Pair it with a mascot — a small stylized gavel icon — and a domain (`verdict.dev` or `getverdict.com`). Consistent branding across the marketplace listing, README, website, and demo GIF is worth ~30% star-conversion uplift based on the case-study research (Opik's rebrand from "CometLLM" is the canonical example).
+`Proofloop` is a good name. Keep it. Pair it with a mascot — a small stylized gavel icon — and a domain (`proofloop.dev` or `getverdict.com`). Consistent branding across the marketplace listing, README, website, and demo GIF is worth ~30% star-conversion uplift based on the case-study research (Opik's rebrand from "CometLLM" is the canonical example).
 
 ---
 
@@ -79,12 +79,12 @@ The "no LLM call" detail matters more than you think — every competitor (Brain
 - Convert to a marketplace plugin with `marketplace.json`.
 - Record a 30-second demo GIF: skill executes, Stop hook fires, Unicode scorecard prints in terminal.
 - Record a 90-second Loom: show the auto-score flow, then the `/scorecard` trend view, then `/benchmark` delta vs standards.
-- Acquire `verdict.dev` or `getverdict.com`.
+- Acquire `proofloop.dev` or `getverdict.com`.
 - Design a gavel logo (Midjourney or a $100 Fiverr commission).
 
 ### Week 1 (launch)
 
-- **Tuesday, 13:00 UTC** — HN submission: *"Verdict: auto-grade every Claude Code skill execution on seven dimensions, no LLM required."* Link the GIF, not the repo.
+- **Tuesday, 13:00 UTC** — HN submission: *"Proofloop: auto-grade every Claude Code skill execution on seven dimensions, no LLM required."* Link the GIF, not the repo.
 - Same day: `/r/ClaudeAI` post (747 k members, highest-leverage subreddit for this project). Format: "I built this plugin because I kept wondering if my skills were actually getting better or if I was just hallucinating improvement." Include screenshots.
 - Submit PRs to `anthropics/claude-plugins-official`, `claudemarketplaces.com`, `aitmpl.com`, `buildwithclaude.com`.
 - X thread: 8 tweets, lead with GIF, one tweet per dimension, final tweet links repo.
@@ -99,16 +99,16 @@ The "no LLM call" detail matters more than you think — every competitor (Brain
 
 ### Weeks 5–8
 
-- Ship Verdict Studio (local dashboard).
+- Ship Proofloop Studio (local dashboard).
 - Small judge-model opt-in (Haiku 4.5 + Atla Selene).
-- agent-airlock OTel integration: "airlock's audit stream + Verdict's scorecards = the agent observability stack."
+- agent-airlock OTel integration: "airlock's audit stream + Proofloop's scorecards = the agent observability stack."
 - Cowork-specific features (team digests via Routines).
 
 ### Weeks 9–12
 
 - Conference submissions: Latent Space Swyx podcast pitch (warm intro via Discord first), Changelog, ThePrimeagen's weekly dev-tool roundup.
-- Verdict v2: rubric versioning, git-diff-aware scoring, regression-aware trends.
-- Partner case studies — 3 teams showing year-over-year skill-quality improvement with Verdict.
+- Proofloop v2: rubric versioning, git-diff-aware scoring, regression-aware trends.
+- Partner case studies — 3 teams showing year-over-year skill-quality improvement with Proofloop.
 
 ### 2026-Q2 Cycle 2 (v1.3.0) — shipped 2026-04-24
 
@@ -117,12 +117,12 @@ signals:
 
 - **Inspect AI log adapter** — UK AISI's `inspect_ai` v0.3 stable
   release (2026-04-20) became the default eval harness for 200+
-  published evaluations. Verdict now ingests its JSON logs directly
+  published evaluations. Proofloop now ingests its JSON logs directly
   (`adapters/inspect_ai_log.py`) so teams that already run Inspect
-  can get Verdict scorecards without re-running their agents.
+  can get Proofloop scorecards without re-running their agents.
 - **`managed-agents-2026-04-01` memory stitch** — Anthropic's
   parallel-agent shared-memory beta emits synthetic records into
-  the JSONL transcript. Verdict tags these with
+  the JSONL transcript. Proofloop tags these with
   `[managed-memory-pull]` / `[managed-memory-push]` so downstream
   analyzers can tell first-party reasoning from memory stitching.
 - **Prompt caching on the LLM judge** — opt-in second-opinion pass
@@ -137,7 +137,7 @@ signals:
   now get a dedicated rubric that weights command-safety + secret-
   leakage at 30%.
 - **OTel GenAI semconv enrichment for MLflow adapter** — MLflow
-  3.11.1 adopted OpenTelemetry GenAI semantic conventions. Verdict
+  3.11.1 adopted OpenTelemetry GenAI semantic conventions. Proofloop
   reads `gen_ai.request.model`, `gen_ai.usage.*`, and
   `gen_ai.response.finish_reasons` so v1.1.0's model-aware
   efficiency thresholds apply to MLflow traces without caller-side
@@ -230,11 +230,11 @@ existing rubric, two new CLI scripts:
   — informational drift between `perception_value` and
   `reality_value` markers. Threshold configurable per deployment
   (Issue O8 — single-data-point anchor, do not over-interpret).
-- **S1** `verdict ship-gate` CLI — pass/fail a scorecard against
+- **S1** `proofloop ship-gate` CLI — pass/fail a scorecard against
   ship_readiness floors, a composite floor, and a regression vs.
   baseline. SARIF v2.1.0 export for the GitHub Actions security tab.
-- **S3** `verdict judge-replay` CLI — re-scores a transcript with
-  the current Verdict and asserts per-dimension stability vs. a
+- **S3** `proofloop judge-replay` CLI — re-scores a transcript with
+  the current Proofloop and asserts per-dimension stability vs. a
   frozen baseline scorecard. Used to validate that a release doesn't
   silently move scores on previously-judged transcripts.
 
@@ -259,13 +259,13 @@ five new CLI scripts. **926 tests green** (800 → 926, +126).
   Signature library refreshable in v1.4.3 (Issue O14).
 - **CC4** Routines (research preview, NOT GA) trajectory adapter
   + `routine-execution` rubric. Heuristic detection opt-in via
-  `VERDICT_DETECT_ROUTINE_HEURISTIC=1` (Issue O15).
-- **T1** `verdict audit-export` CLI — DPO-ready zip bundler with
+  `PROOFLOOP_DETECT_ROUTINE_HEURISTIC=1` (Issue O15).
+- **T1** `proofloop audit-export` CLI — DPO-ready zip bundler with
   best-effort PII redaction. Refuses clinical transcripts per
   Issue O16.
-- **T2** `verdict bench gaming-check` CLI — wraps CC3's detector
+- **T2** `proofloop bench gaming-check` CLI — wraps CC3's detector
   for benchmark publishers / paper authors.
-- **T3** `verdict hook lint` CLI — static analyzer for
+- **T3** `proofloop hook lint` CLI — static analyzer for
   PostToolUse hook scripts. F1–F4 rule set + 2 example hooks.
 
 Open issues filed: O12 (encoding bypass), O13 (counsel review
@@ -313,7 +313,7 @@ pending), O14 (signature drift), O15 (heuristic opt-in), O16
 
 ## 6. Distribution-specific tactic
 
-Verdict's single strongest growth lever is being first in the Anthropic plugin marketplace with this category. The marketplace is searched by every new Claude Code user; being the #1 result for "evaluator" or "quality" nets passive installs forever. Priority actions to secure that:
+Proofloop's single strongest growth lever is being first in the Anthropic plugin marketplace with this category. The marketplace is searched by every new Claude Code user; being the #1 result for "evaluator" or "quality" nets passive installs forever. Priority actions to secure that:
 
 1. Nominate to `anthropics/claude-plugins-official` immediately — it's reviewed by Anthropic's plugin team.
 2. Brand the marketplace listing with a clear hero image, a 20-second looping GIF, and "zero config, zero LLM cost" framing in the first line.
@@ -323,4 +323,4 @@ Verdict's single strongest growth lever is being first in the Anthropic plugin m
 
 ## 7. The CEO-readable one-pager
 
-> *Verdict* is a Claude Code and Cowork plugin that auto-scores every skill and sub-agent execution on seven dimensions — correctness, completeness, adherence, actionability, efficiency, safety, consistency — using fast offline heuristics (no LLM call required). Persistent scorecards track quality over time; per-domain rubrics (code review, design, security, devops, and 7 more) tune the scoring to the work at hand; an opt-in small judge model adds a second-opinion pass when you want it. Verdict is the quality layer for any AI-coding stack — Claude Code, Cowork, Codex, Gemini CLI, Cursor, Continue — and it pairs with agent-airlock's runtime audit stream for end-to-end observability. Zero config, zero third-party dependencies, zero ongoing LLM cost. Install from the Claude plugin marketplace in one command.
+> *Proofloop* is a Claude Code and Cowork plugin that auto-scores every skill and sub-agent execution on seven dimensions — correctness, completeness, adherence, actionability, efficiency, safety, consistency — using fast offline heuristics (no LLM call required). Persistent scorecards track quality over time; per-domain rubrics (code review, design, security, devops, and 7 more) tune the scoring to the work at hand; an opt-in small judge model adds a second-opinion pass when you want it. Proofloop is the quality layer for any AI-coding stack — Claude Code, Cowork, Codex, Gemini CLI, Cursor, Continue — and it pairs with agent-airlock's runtime audit stream for end-to-end observability. Zero config, zero third-party dependencies, zero ongoing LLM cost. Install from the Claude plugin marketplace in one command.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security policy
 
-Verdict ships as a local Claude Code / Cowork plugin. It does not
+Proofloop ships as a local Claude Code / Cowork plugin. It does not
 collect telemetry, does not make network calls, and depends on no
 third-party Python packages. Its threat surface is therefore narrow —
 but report anything that looks wrong.
@@ -10,7 +10,7 @@ but report anything that looks wrong.
 **Do not open a public GitHub issue for security reports.** Instead:
 
 1. Email **<sattyamjain96@gmail.com>** with a subject line of the form
-   `[Verdict security] <one-line summary>`.
+   `[Proofloop security] <one-line summary>`.
 2. Include:
    - Affected version (`git describe --tags`).
    - Reproduction steps or a proof-of-concept — ideally against the
@@ -45,7 +45,7 @@ Out of scope (report to the upstream project instead):
 - Claude Code itself — <https://github.com/anthropics/claude-code>.
 - Claude Cowork / claude.ai infrastructure — <https://support.claude.com>.
 - Third-party rubrics installed via `scripts/install_rubric.py` — the
-  rubric's own maintainer is responsible. Verdict does validate the
+  rubric's own maintainer is responsible. Proofloop does validate the
   rubric structure before install; a validation bypass *is* in scope.
 
 ## Hardening already in place
@@ -59,7 +59,7 @@ analyser itself — so the tool detects the class of risk it could
 otherwise introduce.
 
 The install-rubric utility (`scripts/install_rubric.py`) fetches only
-over HTTPS and validates that downloaded markdown contains the Verdict
+over HTTPS and validates that downloaded markdown contains the Proofloop
 dimension headings before writing it to disk — a malformed or
 intentionally-crafted rubric cannot execute code at install time.
 

--- a/agents/judge-agent.md
+++ b/agents/judge-agent.md
@@ -1,6 +1,6 @@
 ---
 name: judge-agent
-displayName: "Verdict Evaluator Agent"
+displayName: "Proofloop Evaluator Agent"
 description: "Read-only isolated agent that evaluates skill/agent execution quality"
 tools:
   - Read
@@ -9,7 +9,7 @@ tools:
   - Bash (read-only commands only)
 ---
 
-# Verdict Evaluator Agent
+# Proofloop Evaluator Agent
 
 ## Role
 
@@ -168,7 +168,7 @@ Use the full 1-10 range. Below is what each score level actually means. Internal
 
 7. **Do not fabricate.** If the transcript is missing, incomplete, or unreadable, report the error honestly. Do not guess scores. Return an error response: `{ "error": "Transcript not found or unreadable", "path": "..." }`.
 
-8. **Self-evaluation is permitted.** If asked to evaluate Verdict itself, apply the same process without special treatment or bias.
+8. **Self-evaluation is permitted.** If asked to evaluate Proofloop itself, apply the same process without special treatment or bias.
 
 ---
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,4 +1,4 @@
-# Verdict regression-gate corpus
+# Proofloop regression-gate corpus
 
 This directory holds the curated transcript corpus that
 [`scripts/benchmark_pack.py`](../scripts/benchmark_pack.py) replays
@@ -9,10 +9,10 @@ if heuristic drift causes any case to regress.
 ## Scope
 
 Per the [v4.3 scope contract](../CLAUDE.md#v43-scope-contract-2026-05-03),
-this is the **regression-gate fixture set for Verdict's heuristic
+this is the **regression-gate fixture set for Proofloop's heuristic
 engine**. It is **NOT a public eval bench:**
 
-- We do not advertise Verdict's leaderboard standing.
+- We do not advertise Proofloop's leaderboard standing.
 - We do not accept SWE-bench, Terminal-Bench, GAIA, OSWorld, or
   similar agent-bench submissions.
 - The fixtures are not curated for cross-tool benchmarking — they
@@ -20,7 +20,7 @@ engine**. It is **NOT a public eval bench:**
 
 If you are looking for an eval bench, run the upstream tool that
 authored the bench and post results there. If you are looking to
-extend Verdict's plugin-scope heuristics, add a case here that
+extend Proofloop's plugin-scope heuristics, add a case here that
 exercises the dimension you are changing and ensure
 `benchmark_pack.py` stays green.
 

--- a/commands/against.md
+++ b/commands/against.md
@@ -36,7 +36,7 @@ Renders a Unicode table comparing two scorecards for the same skill
 
    ```
    ╭────────────────────────────╮
-   │ Verdict delta: code-review │
+   │ Proofloop delta: code-review │
    ╰────────────────────────────╯
    baseline: 2026-04-10T12:00:00Z  composite 7.80/B
    target:   2026-04-18T12:00:00Z  composite 8.60/A-
@@ -53,7 +53,7 @@ Renders a Unicode table comparing two scorecards for the same skill
    ─────────────────────────────────────────────
    composite         7.80     8.60   +0.80 ↑
 
-   Verdict: IMPROVED (+0.80)
+   Proofloop: IMPROVED (+0.80)
    ```
 
 3. Exit semantics:

--- a/commands/benchmark.md
+++ b/commands/benchmark.md
@@ -21,7 +21,7 @@ Compare a skill's historical performance against defined benchmark standards.
 
 ```
 ┌───────────────────────────────────────────────────────────────┐
-│  VERDICT BENCHMARK — {skill-name}                          │
+│  PROOFLOOP BENCHMARK — {skill-name}                          │
 ├────────────────┬──────────┬───────────┬───────────────────────┤
 │ Dimension      │ Your Avg │ Benchmark │ Delta                 │
 ├────────────────┼──────────┼───────────┼───────────────────────┤

--- a/commands/compare.md
+++ b/commands/compare.md
@@ -1,6 +1,6 @@
 ---
 name: compare
-description: "Compare two Verdict scorecards of the same skill with a narrative overlay"
+description: "Compare two Proofloop scorecards of the same skill with a narrative overlay"
 usage: "/compare --run-a <path> --run-b <path> [--format text|json]"
 ---
 

--- a/commands/judge-config.md
+++ b/commands/judge-config.md
@@ -1,12 +1,12 @@
 ---
 name: judge-config
-description: "View and manage Verdict auto-judge configuration"
+description: "View and manage Proofloop auto-judge configuration"
 usage: "/judge-config [subcommand] [args]"
 ---
 
 # /judge-config — Manage Auto-Judge Settings
 
-View and modify the Verdict configuration.
+View and modify the Proofloop configuration.
 
 ## Subcommands
 
@@ -24,7 +24,7 @@ View and modify the Verdict configuration.
 2. If no subcommand: display the full config in a readable format:
 
 ```
-Verdict Configuration
+Proofloop Configuration
 ========================
 Auto-Judge: ENABLED
 Threshold: 5.0 (skills scoring below this are BLOCKED)
@@ -75,7 +75,7 @@ Tokenizer Baselines (efficiency length-threshold multipliers):
 
 ## Weight validation
 
-When the user edits `scoring.dimensions` directly, Verdict enforces the
+When the user edits `scoring.dimensions` directly, Proofloop enforces the
 weight-sum-to-1.0 invariant at load time. Non-conforming configs are
 rejected with a stderr warning and the scorer falls back to default
 weights instead of silently producing inflated composites. Run

--- a/commands/judge.md
+++ b/commands/judge.md
@@ -6,7 +6,7 @@ usage: "/judge [skill-name] [--rubric RUBRIC] [--verbose] [--adapter NAME] [--mo
 
 # /judge — Manual Skill Quality Evaluation
 
-You are Verdict, the universal quality evaluator for Claude Code skills and agents.
+You are Proofloop, the universal quality evaluator for Claude Code skills and agents.
 
 ## Your Task
 
@@ -20,7 +20,7 @@ When the user invokes `/judge`, evaluate the most recent skill or agent executio
 - `--adapter NAME` (optional): Transcript adapter for non-native ecosystems. One of `claude-code`, `cowork`, `openai-compatible`, `codex`, `cursor`, `continue`.
 - `--model ID` (optional): Model ID override (e.g., `claude-opus-4-7`). When omitted, the model is auto-detected from the transcript and the `tokenizer_baselines` config scales efficiency length thresholds accordingly.
 - `--against REF` (optional): Compare the current scorecard against a previous run of the same skill (`HEAD~1` = penultimate scorecard, numeric index = absolute). Delegates to `skills/judge/scripts/against.py` and exits non-zero on composite regression.
-- `--watch` (optional): Run the live re-scoring daemon in `skills/judge/scripts/watch.py`. Polls the scores directory every 2 s, prints a one-line diff header per change (`improved X, regressed Y, unchanged Z since last run`), and re-emits Verdict Studio to the `--output` HTML path. Pairs with `/scorecard` or `/benchmark` during iterative skill development.
+- `--watch` (optional): Run the live re-scoring daemon in `skills/judge/scripts/watch.py`. Polls the scores directory every 2 s, prints a one-line diff header per change (`improved X, regressed Y, unchanged Z since last run`), and re-emits Proofloop Studio to the `--output` HTML path. Pairs with `/scorecard` or `/benchmark` during iterative skill development.
 - `--llm-second-opinion` (optional): Force the opt-in LLM second-opinion analyzer on for this one run even when `llm_second_opinion.enabled = false` in `judge-config.json`. Requires `ANTHROPIC_API_KEY`. See `skills/judge/analyzers/llm_judge.py`.
 - `--explain SCORECARD` (optional): Render an existing scorecard JSON in either Markdown (PR-friendly) or JSON (CI-friendly). Delegates to `skills/judge/scripts/explain.py`. Pair with `--format md|json` (default `md`) and optional `--out PATH`. Example: `/judge --explain skills/judge/scores/code-review_2026-04-25.json --format md`. See [`SKILL-judge-explain.md`](../skills/judge/SKILL-judge-explain.md) for the output schema.
 - **See also `/compare`** for explicit two-file delta with Auto Memory regression narrative — complement to `/judge --against HEAD~1`.
@@ -73,7 +73,7 @@ When the user invokes `/judge`, evaluate the most recent skill or agent executio
 
 ```
 ╔═══════════════════════════════════════════════════════════════╗
-║  VERDICT SCORECARD — {skill-name}                          ║
+║  PROOFLOOP SCORECARD — {skill-name}                          ║
 ╠═══════════════════════════════════════════════════════════════╣
 ║                                                               ║
 ║  Correctness    {bar}  {score}/10  {justification}            ║

--- a/commands/scorecard.md
+++ b/commands/scorecard.md
@@ -6,7 +6,7 @@ usage: "/scorecard [skill-name] [--last N] [--all]"
 
 # /scorecard — Score History & Trends
 
-Display historical scores for skills that have been evaluated by Verdict.
+Display historical scores for skills that have been evaluated by Proofloop.
 
 ## Arguments
 
@@ -25,7 +25,7 @@ Display historical scores for skills that have been evaluated by Verdict.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│  VERDICT SCORE HISTORY                                   │
+│  PROOFLOOP SCORE HISTORY                                   │
 ├──────────────┬───────┬───────┬────────────┬────────────────┤
 │ Skill        │ Score │ Grade │ Date       │ Trend          │
 ├──────────────┼───────┼───────┼────────────┼────────────────┤
@@ -51,5 +51,5 @@ If no scores exist yet, inform the user: "No scores found. Run `/judge` after a 
 
 - `/against` — side-by-side delta between two specific runs of the same skill.
 - `/benchmark` — delta between a skill's historical average and the reference standards in `skills/judge/references/benchmark-standards.md`.
-- `python3 skills/judge/scripts/studio.py --scores-dir skills/judge/scores --output verdict-studio.html` — self-contained HTML dashboard with per-skill radar charts.
+- `python3 skills/judge/scripts/studio.py --scores-dir skills/judge/scores --output proofloop-studio.html` — self-contained HTML dashboard with per-skill radar charts.
 

--- a/docs/cli/hook-lint.md
+++ b/docs/cli/hook-lint.md
@@ -1,4 +1,4 @@
-# `verdict hook lint` CLI
+# `proofloop hook lint` CLI
 
 Static analyzer for Claude Code PostToolUse hook scripts. Flags
 safety-relevant patterns in the hook **source** so adopters can

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -28,7 +28,7 @@ Each upstream marketplace is its own PR; they can't be generated
 automatically because they require your GitHub identity.
 
 - [ ] `anthropics/claude-plugins-official` — add a plugin entry
-      pointing at `github.com/sattyamjjain/verdict`. Use the existing
+      pointing at `github.com/sattyamjjain/proofloop`. Use the existing
       `.claude-plugin/marketplace.json` as the source of truth.
 - [ ] `claudemarketplaces.com` — follow their PR template.
 - [ ] `aitmpl.com` — same.
@@ -42,7 +42,7 @@ valid.
 
 Pick one; tell me which before registering.
 
-- `verdict.dev` — preferred.
+- `proofloop.dev` — preferred.
 - `getverdict.com` — fallback.
 
 Point DNS at Cloudflare Pages once the docs site lands.
@@ -78,8 +78,8 @@ Each of these has a prepared draft under `docs/launch/`:
       anonymised scorecards from opt-in users (requires an opt-in flag
       in `judge-config.json` first; not yet implemented).
 - [ ] Case studies (weeks 8, 10, 12) — three teams showing QoQ skill-
-      quality improvement with Verdict.
-- [ ] `rubrics.verdict.dev` — static Cloudflare Pages index of
+      quality improvement with Proofloop.
+- [ ] `rubrics.proofloop.dev` — static Cloudflare Pages index of
       community rubrics once 10+ community contributions land.
 
 ## Items I deliberately did NOT ship

--- a/docs/launch/dm-templates.md
+++ b/docs/launch/dm-templates.md
@@ -2,14 +2,14 @@
 
 Ten creators, each DM personalised with a demo run against one of their
 recent public transcripts. The pattern is the same: open with a
-concrete observation from their work, attach a specific Verdict output,
+concrete observation from their work, attach a specific Proofloop output,
 end with a single ask (try it / boost it / give feedback).
 
 ## Template
 
 > Hey {name} —
 >
-> loved your recent {specific thing they shipped}. I ran Verdict
+> loved your recent {specific thing they shipped}. I ran Proofloop
 > against {public transcript or PR}, and the scorecard flagged
 > {specific dimension} at {score}/10 with the note {justification}.
 >
@@ -17,23 +17,23 @@ end with a single ask (try it / boost it / give feedback).
 >
 > I'd love a 90-second reaction if you have time. No ask beyond that.
 >
-> install: /plugin marketplace add sattyamjjain/verdict
-> source: github.com/sattyamjjain/verdict
+> install: /plugin marketplace add sattyamjjain/proofloop
+> source: github.com/sattyamjjain/proofloop
 >
 > — sattyam
 
 ## Targets (in order of leverage)
 
 1. **swyx (@swyx)** — Latent Space / dev tooling authority. He has
-   explicit Claude Code and skills content; Verdict is exactly his beat.
+   explicit Claude Code and skills content; Proofloop is exactly his beat.
 2. **Theo (@theo)** — T3 Stack / dev-tool takes. Audience overlap with
    Claude Code is high.
 3. **simonw (@simonw)** — Django lineage, ships CLI tools, writes
-   about eval pipelines. Verdict's CLI surface is aligned to his taste.
+   about eval pipelines. Proofloop's CLI surface is aligned to his taste.
 4. **karpathy (@karpathy)** — reach > any nominal fit. Only DM if the
    demo scorecard is airtight (run on one of his public repos first).
 5. **matthewberman** — YouTube Claude / AI content; 300k subs.
-6. **hwchase17** — LangChain author. Verdict competes with LangSmith;
+6. **hwchase17** — LangChain author. Proofloop competes with LangSmith;
    position this carefully as "different category, not a competitor."
 7. **ggerganov** — llama.cpp author. Offline-first heuristics will
    resonate; expect tough questions on the heuristic accuracy floor.

--- a/docs/launch/hn-faq.md
+++ b/docs/launch/hn-faq.md
@@ -1,7 +1,7 @@
 # HN Launch FAQ
 
 **Submission title (under 80 chars):**
-*Verdict: auto-grade every Claude Code skill execution on seven dimensions, no LLM*
+*Proofloop: auto-grade every Claude Code skill execution on seven dimensions, no LLM*
 
 **Link:** demo GIF (not the repo). The repo + docs live in the first comment.
 
@@ -24,7 +24,7 @@ globally and `<rubric>.weights.json` lets you override per rubric.
 
 Almost the opposite. Every competitor calls an LLM to grade the output
 — which costs money, adds latency, and has the meta-problem of "who
-grades the grader." Verdict runs offline regex heuristics against the
+grades the grader." Proofloop runs offline regex heuristics against the
 transcript. It's inferior to LLM-as-judge on nuanced judgment calls,
 and we say so in the README, but the trade-off is: zero ongoing cost,
 no API key, no network call, integrates as a Claude Code plugin with a
@@ -52,11 +52,11 @@ reintroduces length-as-proxy-for-completeness breaks the build.
 
 Those are hosted observability platforms for LLM apps. You send traces
 over HTTPS, they render dashboards, you write eval functions in Python
-or TypeScript. Verdict is a Claude Code plugin — you install it from
+or TypeScript. Proofloop is a Claude Code plugin — you install it from
 the marketplace, and every `Stop` event in your editor is scored and
 dropped into a local scorecard. No server, no traces, no API key.
 
-The moat isn't features; it's distribution. Verdict is the only tool in
+The moat isn't features; it's distribution. Proofloop is the only tool in
 the category that ships inside the editor.
 
 ### "Does it support Cursor / Codex / Gemini CLI?"
@@ -73,7 +73,7 @@ A transcript of "I found no issues with this code" on a clearly buggy
 file scores 9.2/A with v1.0 because there are no error keywords, no
 TODOs, and the transcript is short. The heuristic can't know the file
 is buggy. The roadmap fixes this with the opt-in small-judge pass;
-until then, Verdict is a signal, not a verdict.
+until then, Proofloop is a signal, not a verdict.
 
 ### "Why is the code so conservative — stdlib only, no LLM, etc?"
 
@@ -84,12 +84,12 @@ Three reasons:
 2. **Deterministic.** The same transcript always scores the same. Good
    for CI regression gates (we ship one) and bad for nuance.
 3. **Cheap.** Some teams burn a lot of LLM tokens on eval pipelines.
-   Verdict is a complement that costs $0 to run forever.
+   Proofloop is a complement that costs $0 to run forever.
 
 ### "Roadmap?"
 
 Issue #2 on the repo has the full 90-day plan — cross-ecosystem launch
 week (Week 2: Codex, then Cursor, Continue, Gemini CLI, Windsurf), the
-Verdict Studio local HTML dashboard (already shipped as
+Proofloop Studio local HTML dashboard (already shipped as
 `scripts/studio.py` actually), an opt-in small-judge model path via
 Haiku 4.5, and a rubric marketplace seeded with the 11 rubrics we ship.

--- a/docs/launch/marketplace-submission.md
+++ b/docs/launch/marketplace-submission.md
@@ -21,18 +21,18 @@ sampled form: `adlc`, `asana`, `zoom-plugin`).
 
 | Form field        | Value                                                                                                                  |
 | ----------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| **Name**          | `verdict`                                                                                                              |
+| **Name**          | `proofloop`                                                                                                              |
 | **Description**   | *See below — two variants depending on character limit.*                                                               |
 | **Category**      | `development` (matches the category of 144 existing entries; fallback: `quality-assurance` if a dropdown offers it)    |
 | **Source type**   | `url` (a.k.a. "Git URL" — same pattern used by all URL-sourced community entries)                                      |
-| **Source URL**    | `https://github.com/sattyamjjain/verdict.git`                                                                          |
-| **Homepage**      | `https://github.com/sattyamjjain/verdict`                                                                               |
+| **Source URL**    | `https://github.com/sattyamjjain/proofloop.git`                                                                          |
+| **Homepage**      | `https://github.com/sattyamjjain/proofloop`                                                                               |
 | **Author**        | `Sattyam Jain`                                                                                                         |
 | **Author email**  | `sattyamjain96@gmail.com`                                                                                              |
 | **License**       | `MIT`                                                                                                                  |
 | **Version**       | `1.1.0`                                                                                                                |
 | **Keywords/tags** | `judge, evaluation, quality, scoring, skills, agents, rubrics`                                                         |
-| **Repository**    | `https://github.com/sattyamjjain/verdict`                                                                              |
+| **Repository**    | `https://github.com/sattyamjjain/proofloop`                                                                              |
 
 ### Description — short (< 100 chars)
 
@@ -45,7 +45,7 @@ sampled form: `adlc`, `asana`, `zoom-plugin`).
 ### Description — long / features list (for any field that allows markdown)
 
 ```markdown
-Verdict auto-evaluates skill and sub-agent execution quality from
+Proofloop auto-evaluates skill and sub-agent execution quality from
 Claude Code's `Stop`, `SubagentStop`, and `StopFailure` hooks.
 
 Key differentiators vs Braintrust / Langfuse / Phoenix / Promptfoo /
@@ -71,14 +71,14 @@ paste this — it matches the shape of existing entries verbatim:
 
 ```json
 {
-  "name": "verdict",
+  "name": "proofloop",
   "description": "Auto-grade every Claude Code and Cowork skill execution on seven dimensions (correctness, completeness, adherence, actionability, efficiency, safety, consistency). Hooks-based auto-scoring + persistent scorecards. Offline heuristics — no LLM call required.",
   "category": "development",
   "source": {
     "source": "url",
-    "url": "https://github.com/sattyamjjain/verdict.git"
+    "url": "https://github.com/sattyamjjain/proofloop.git"
   },
-  "homepage": "https://github.com/sattyamjjain/verdict"
+  "homepage": "https://github.com/sattyamjjain/proofloop"
 }
 ```
 
@@ -95,10 +95,10 @@ review team catches every one of them:
 - [x] `CHANGELOG.md` includes a v1.1.0 entry — ✓
 - [x] `.claude-plugin/marketplace.json` passes `scripts/validate_marketplace.py` — ✓
 - [x] CI workflow runs on PRs and is currently green — ✓ (two consecutive green runs)
-- [x] Repository is **public** — verify at <https://github.com/sattyamjjain/verdict>
+- [x] Repository is **public** — verify at <https://github.com/sattyamjjain/proofloop>
 - [x] No secrets, tokens, or credentials in git history — safe (no `.env`, `credentials.*`, etc.)
 - [x] Version tag `v1.1.0` exists and is signed / annotated — ✓
-- [x] Release notes published — ✓ <https://github.com/sattyamjjain/verdict/releases/tag/v1.1.0>
+- [x] Release notes published — ✓ <https://github.com/sattyamjjain/proofloop/releases/tag/v1.1.0>
 
 ## Assets to attach (if the form accepts files)
 
@@ -116,13 +116,13 @@ Common rejection reasons and fixes:
 
 1. **"Name conflicts with existing plugin"** — our `name: "verdict"`
    is unique in the 144-entry snapshot, but the team may reserve the
-   name internally. Fallback: resubmit as `verdict-judge` and update
+   name internally. Fallback: resubmit as `proofloop-judge` and update
    `plugin.json` + `marketplace.json` accordingly.
 2. **"Description exceeds N characters"** — use the short variant above.
 3. **"README missing required section (installation / usage / license)"**
    — our README has all three.
 4. **"Version string doesn't match a published tag"** — reply with
-   a link to <https://github.com/sattyamjjain/verdict/releases/tag/v1.1.0>.
+   a link to <https://github.com/sattyamjjain/proofloop/releases/tag/v1.1.0>.
 
 ## Post-submission followup
 

--- a/docs/launch/pitches.md
+++ b/docs/launch/pitches.md
@@ -2,19 +2,19 @@
 
 ## Latent Space (swyx / Alessio)
 
-**Subject:** Verdict — offline heuristic scoring for Claude Code skills (Stop-hook native)
+**Subject:** Proofloop — offline heuristic scoring for Claude Code skills (Stop-hook native)
 
 Hey swyx / Alessio,
 
-Just shipped Verdict, a Claude Code plugin that scores every skill /
+Just shipped Proofloop, a Claude Code plugin that scores every skill /
 subagent execution on seven dimensions from the Stop hook, offline,
 no LLM call. The moat isn't features — it's distribution: every other
-tool in this space asks you to wire traces into a SaaS. Verdict runs
+tool in this space asks you to wire traces into a SaaS. Proofloop runs
 inside the editor.
 
 Would love to do a Latent Space episode on the offline-heuristics
 design decision, why stdlib-only matters for plugin distribution, and
-where Verdict fits relative to Braintrust / Langfuse / Ragas / Opik.
+where Proofloop fits relative to Braintrust / Langfuse / Ragas / Opik.
 
 Happy to bring data from the first 14 days of launch — install counts,
 grade distributions by rubric, drift-detection anecdotes.
@@ -29,7 +29,7 @@ Discord intro if it's easier: {user handle}.
 
 Hi Adam —
 
-Verdict shipped v1.1.0 last week. It's a Claude Code plugin that
+Proofloop shipped v1.1.0 last week. It's a Claude Code plugin that
 auto-scores skill and subagent executions on seven dimensions using
 offline heuristics (no LLM call, no API key, no hosted service). Cross-
 ecosystem from day one: Codex, Cursor, Continue, Gemini CLI, Cowork

--- a/docs/launch/reddit-post.md
+++ b/docs/launch/reddit-post.md
@@ -14,7 +14,7 @@ was either a hosted observability platform I'd have to wire traces
 into, or a Python eval library I'd have to script. None of them plugged
 into Claude Code, and all of them needed a second LLM to do the grading.
 
-So I built Verdict.
+So I built Proofloop.
 
 It's a Claude Code plugin. You install it from the marketplace, and
 from that point on every `Stop` hook (skill finishes) and
@@ -27,7 +27,7 @@ Persists the scorecard to JSON so `/scorecard` can render trends.
 Install:
 
 ```
-/plugin marketplace add sattyamjjain/verdict
+/plugin marketplace add sattyamjjain/proofloop
 /plugin install verdict@verdict
 ```
 

--- a/docs/launch/x-thread.md
+++ b/docs/launch/x-thread.md
@@ -8,7 +8,7 @@ tweet self-contained — people quote individual tweets.
 every time i ship a claude code skill i wonder: did it actually get
 better, or am i hallucinating improvement?
 
-so i built Verdict — a plugin that auto-grades every skill and subagent
+so i built Proofloop — a plugin that auto-grades every skill and subagent
 execution on seven dimensions the moment the Stop hook fires.
 
 no LLM call. no config. just a scorecard.
@@ -31,7 +31,7 @@ Promptfoo, DeepEval, Ragas, LangSmith, Opik) needs a second LLM to
 grade the first one. that costs money. adds latency. and has a
 meta-problem: who grades the grader?
 
-Verdict runs offline regex heuristics.
+Proofloop runs offline regex heuristics.
 
 ## 4/
 
@@ -47,7 +47,7 @@ one flag: `--adapter codex`.
 
 the plugin installs like any Claude Code plugin:
 
-`/plugin marketplace add sattyamjjain/verdict`
+`/plugin marketplace add sattyamjjain/proofloop`
 `/plugin install verdict@verdict`
 
 next Stop hook that fires on an allowlisted skill triggers a score in
@@ -67,7 +67,7 @@ Opus 4.7 tokenizer awareness.
 what's next:
 
 — `/judge --against HEAD~1` (shipped)
-— Verdict Studio local HTML dashboard (shipped)
+— Proofloop Studio local HTML dashboard (shipped)
 — opt-in small-judge via Haiku 4.5 for the nuanced cases
 — rubric marketplace seeded with 11 domain rubrics
 — weekly team digest via Anthropic Routines
@@ -77,10 +77,10 @@ issue #2 has the 90-day plan.
 ## 8/ (CTA)
 
 install:
-`/plugin marketplace add sattyamjjain/verdict`
+`/plugin marketplace add sattyamjjain/proofloop`
 
-source + docs: github.com/sattyamjjain/verdict
+source + docs: github.com/sattyamjjain/proofloop
 discord: (invite in the README once created)
 
 if you've been wondering whether your skills are actually getting
-better, stop guessing. let Verdict tell you.
+better, stop guessing. let Proofloop tell you.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,4 +1,4 @@
-# Verdict metrics
+# Proofloop metrics
 
 Updated weekly. Tracks the launch-to-1000-stars goal and surfaces
 regressions in the quality / distribution funnel. See ROADMAP_2026 §10
@@ -12,8 +12,8 @@ without bloating the header.
 
 ```shell
 # Numbers that can be read mechanically
-gh api repos/sattyamjjain/verdict --jq '.stargazers_count'
-gh api repos/sattyamjjain/verdict/traffic/views
+gh api repos/sattyamjjain/proofloop --jq '.stargazers_count'
+gh api repos/sattyamjjain/proofloop/traffic/views
 git log --since='1 week ago' --oneline | wc -l
 python3 -m unittest discover tests/ 2>&1 | grep -E 'Ran [0-9]+'
 python3 scripts/benchmark_pack.py 2>&1 | tail -5

--- a/docs/research-log.md
+++ b/docs/research-log.md
@@ -1,7 +1,7 @@
 # Research log
 
 Citations and retrieval dates for every external claim that shapes
-Verdict's implementation. Add a new entry each time you verify a spec
+Proofloop's implementation. Add a new entry each time you verify a spec
 before shipping code that depends on it.
 
 ## 2026-04-18 — Claude Code hooks reference
@@ -21,14 +21,14 @@ before shipping code that depends on it.
   `transcript_path`, `cwd`, `permission_mode`, `hook_event_name`,
   `stop_hook_active`, `agent_id`, `agent_type`,
   `agent_transcript_path`, `last_assistant_message`. The subagent's own
-  transcript is at `agent_transcript_path` — Verdict should score that
+  transcript is at `agent_transcript_path` — Proofloop should score that
   file when it is present, falling back to `transcript_path` otherwise.
 - `StopFailure` fires when the turn ends due to an API error
   (rate_limit / authentication_failed / billing_error / invalid_request /
   server_error / max_output_tokens / unknown). Output/exit code are
-  ignored. Verdict should not auto-judge on this event.
+  ignored. Proofloop should not auto-judge on this event.
 - Default timeouts: command hooks 600s, prompt hooks 30s, agent hooks
-  60s. Verdict currently specifies `"timeout": 120` explicitly.
+  60s. Proofloop currently specifies `"timeout": 120` explicitly.
 - Exit codes: 0 success; 2 blocks (effect varies per event); any other
   non-zero is a non-blocking error.
 
@@ -51,7 +51,7 @@ before shipping code that depends on it.
   (`skills`, `commands`, `agents`, `hooks`, `mcpServers`, `lspServers`).
 - **Reserved marketplace names** include `claude-plugins-official`,
   `anthropic-plugins`, `agent-skills`, and impersonation variants —
-  Verdict's `"name": "verdict"` is fine.
+  Proofloop's `"name": "verdict"` is fine.
 - Schema URL `https://anthropic.com/claude-code/marketplace.schema.json`
   is referenced but does not resolve (confirmed via
   <https://github.com/anthropics/claude-code/issues/9686>). Validation
@@ -64,7 +64,7 @@ before shipping code that depends on it.
 - Routines launched 2026-04-14 as research preview. Scheduled, API, and
   GitHub triggers all produce **normal Claude Code cloud sessions** with
   the routine prompt acting as the user turn.
-- Implication for Verdict: the existing `Stop` hook fires normally when
+- Implication for Proofloop: the existing `Stop` hook fires normally when
   a routine finishes. No `--mode routine` flag is required to handle a
   "missing user turn" — the user turn is the routine prompt. Document
   the behavior; no transcript-format change.
@@ -83,7 +83,7 @@ before shipping code that depends on it.
     context, 64k max output
 - Opus 4.7 uses a new tokenizer that produces **~1.0x–1.35x** as many
   tokens as Opus 4.6 for the same text (up to 35% more, content-dependent).
-- Verdict uses line/char counts, not real tokens, so the tokenizer
+- Proofloop uses line/char counts, not real tokens, so the tokenizer
   change affects length-based thresholds indirectly. Model-aware scaling
   of the efficiency thresholds (2000/1000 lines) prevents first-run
   regressions when the same skill moves to Opus 4.7.

--- a/docs/schema-registry.md
+++ b/docs/schema-registry.md
@@ -1,14 +1,14 @@
-# Verdict schema registry
+# Proofloop schema registry
 
-Verdict publishes its public JSON schemas at a stable URL so
+Proofloop publishes its public JSON schemas at a stable URL so
 downstream consumers can validate scorecards (and future envelopes)
-without cloning the Verdict repository.
+without cloning the Proofloop repository.
 
 ## Canonical URLs
 
 | Schema                 | Version | URL |
 | ---------------------- | :-----: | --- |
-| Scorecard              | v1      | <https://verdict.dev/schemas/scorecard.v1.json> |
+| Scorecard              | v1      | <https://proofloop.dev/schemas/scorecard.v1.json> |
 
 The `$schema` field in every emitted scorecard points at the
 corresponding URL. Consumers should parse `schemaVersion` first and
@@ -16,7 +16,7 @@ gate on `>= 1.0.0, < 2.0.0` for the v1 line.
 
 ## Transport
 
-Until `verdict.dev` is claimed, the registry is served from **GitHub
+Until `proofloop.dev` is claimed, the registry is served from **GitHub
 Pages** on this repository. The workflow in
 `.github/workflows/pages.yml` mirrors every file under `schemas/` into
 the `gh-pages` branch on every push to `main`, preserving the
@@ -28,7 +28,7 @@ https://sattyamjjain.github.io/verdict/schemas/scorecard.v1.json
 
 Once the domain is live, it will be a simple CNAME over the same
 Pages deployment — no schema bodies change, only the hostname.
-Consumers pinned to `https://verdict.dev/schemas/…` will resolve
+Consumers pinned to `https://proofloop.dev/schemas/…` will resolve
 through the CNAME from day one.
 
 ## Evolution rules
@@ -50,7 +50,7 @@ resolving, every consumer can pin to the in-repo path
 identical content.
 
 No roadmap entry for a paid / hosted schema registry — it would break
-the offline-first pitch Verdict is built on.
+the offline-first pitch Proofloop is built on.
 
 ## Adding a new schema
 

--- a/hooks/common.sh
+++ b/hooks/common.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-# Verdict — Common hook utilities
+# Proofloop — Common hook utilities
 
 # Check required dependencies
 _check_dependency() {
   local cmd="$1"
   local install_hint="$2"
   if ! command -v "$cmd" >/dev/null 2>&1; then
-    echo "Verdict: requires '$cmd' but it is not installed. $install_hint" >&2
+    echo "Proofloop: requires '$cmd' but it is not installed. $install_hint" >&2
     return 1
   fi
   return 0

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Verdict — Auto-evaluate skill and agent execution quality",
+  "description": "Proofloop — Auto-evaluate skill and agent execution quality",
   "hooks": {
     "Stop": [
       {

--- a/hooks/judge-on-stop-failure.sh
+++ b/hooks/judge-on-stop-failure.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Verdict — StopFailure hook
+# Proofloop — StopFailure hook
 #
 # Claude Code fires StopFailure when a turn ends due to an API error
 # (rate_limit, authentication_failed, billing_error, invalid_request,
@@ -19,5 +19,5 @@ INPUT=$(cat)
 ERROR_TYPE=$(echo "$INPUT" | jq -r '.matcher // "unknown"' 2>/dev/null)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null)
 
-echo "Verdict: skipping auto-judge for session $SESSION_ID — StopFailure ($ERROR_TYPE)." >&2
+echo "Proofloop: skipping auto-judge for session $SESSION_ID — StopFailure ($ERROR_TYPE)." >&2
 exit 0

--- a/hooks/judge-on-stop.sh
+++ b/hooks/judge-on-stop.sh
@@ -30,7 +30,7 @@ SCORECARD=$(python3 "$PLUGIN_ROOT/skills/judge/scripts/score.py" \
   --rubric-dir "$PLUGIN_ROOT/skills/judge/rubrics" \
   --scores-dir "$PLUGIN_ROOT/skills/judge/scores" \
   --config "$CONFIG_PATH" 2>&1) || {
-    echo "Verdict: Scoring failed for $SKILL_NAME" >&2
+    echo "Proofloop: Scoring failed for $SKILL_NAME" >&2
     exit 0  # Don't block on scoring errors
   }
 
@@ -47,7 +47,7 @@ if [ -n "$SCORE" ] && [ -n "$THRESHOLD" ]; then
     # BLOCK: Score below threshold
     SUMMARY=$(echo "$SCORECARD" | jq -r '.summary // "Quality below threshold"' 2>/dev/null)
     ISSUES=$(echo "$SCORECARD" | jq -r '.critical_issues // [] | join("; ")' 2>/dev/null)
-    echo "Verdict BLOCKED: $SKILL_NAME scored $SCORE/10 ($GRADE) — below threshold of $THRESHOLD" >&2
+    echo "Proofloop BLOCKED: $SKILL_NAME scored $SCORE/10 ($GRADE) — below threshold of $THRESHOLD" >&2
     echo "Issues: $ISSUES" >&2
     echo "Summary: $SUMMARY" >&2
     exit 2
@@ -63,14 +63,14 @@ if [ "$COLLAPSE" = "true" ]; then
   REASON=$(echo "$SCORECARD" | jq -r '.dimensions.consistency.verifier_collapse_reason // "verifier collapse detected"' 2>/dev/null)
   case "$GATE_MODE" in
     fail)
-      echo "Verdict BLOCKED: verifier collapse detected for $SKILL_NAME — $REASON" >&2
+      echo "Proofloop BLOCKED: verifier collapse detected for $SKILL_NAME — $REASON" >&2
       echo "Tip: set judge-config.json.verifier_collapse.gate_mode to \"warn\" to demote to a warning." >&2
       exit 2
       ;;
     off)
       ;;  # silent
     *)
-      echo "Verdict WARNING: verifier collapse detected for $SKILL_NAME — $REASON" >&2
+      echo "Proofloop WARNING: verifier collapse detected for $SKILL_NAME — $REASON" >&2
       echo "Tip: set judge-config.json.verifier_collapse.gate_mode to \"fail\" to block on this signal." >&2
       ;;
   esac
@@ -81,7 +81,7 @@ cat <<EOF
 {
   "hookSpecificOutput": {
     "hookEventName": "Stop",
-    "additionalContext": "Verdict: $SKILL_NAME → $SCORE/10 ($GRADE). $ONE_LINER"
+    "additionalContext": "Proofloop: $SKILL_NAME → $SCORE/10 ($GRADE). $ONE_LINER"
   }
 }
 EOF

--- a/hooks/judge-on-subagent-stop.sh
+++ b/hooks/judge-on-subagent-stop.sh
@@ -29,7 +29,7 @@ SCORECARD=$(python3 "$PLUGIN_ROOT/skills/judge/scripts/score.py" \
   --rubric-dir "$PLUGIN_ROOT/skills/judge/rubrics" \
   --scores-dir "$PLUGIN_ROOT/skills/judge/scores" \
   --config "$CONFIG_PATH" 2>&1) || {
-    echo "Verdict: Scoring failed for agent $AGENT_TYPE" >&2
+    echo "Proofloop: Scoring failed for agent $AGENT_TYPE" >&2
     exit 0
   }
 
@@ -45,7 +45,7 @@ if [ -n "$SCORE" ] && [ -n "$THRESHOLD" ]; then
   if [ "$BELOW" = "1" ]; then
     SUMMARY=$(echo "$SCORECARD" | jq -r '.summary // "Quality below threshold"' 2>/dev/null)
     ISSUES=$(echo "$SCORECARD" | jq -r '.critical_issues // [] | join("; ")' 2>/dev/null)
-    echo "Verdict BLOCKED: Agent $AGENT_TYPE scored $SCORE/10 ($GRADE) — below threshold of $THRESHOLD" >&2
+    echo "Proofloop BLOCKED: Agent $AGENT_TYPE scored $SCORE/10 ($GRADE) — below threshold of $THRESHOLD" >&2
     echo "Issues: $ISSUES" >&2
     echo "Summary: $SUMMARY" >&2
     exit 2
@@ -57,7 +57,7 @@ cat <<EOF
 {
   "hookSpecificOutput": {
     "hookEventName": "SubagentStop",
-    "additionalContext": "Verdict: Agent $AGENT_TYPE → $SCORE/10 ($GRADE). $ONE_LINER"
+    "additionalContext": "Proofloop: Agent $AGENT_TYPE → $SCORE/10 ($GRADE). $ONE_LINER"
   }
 }
 EOF

--- a/routines/weekly-team-digest.md
+++ b/routines/weekly-team-digest.md
@@ -1,20 +1,20 @@
 ---
-name: Verdict weekly team digest
+name: Proofloop weekly team digest
 schedule: weekly
-description: Post a weekly quality digest to Slack summarising Verdict scorecards.
+description: Post a weekly quality digest to Slack summarising Proofloop scorecards.
 ---
 
-# Weekly Verdict team digest
+# Weekly Proofloop team digest
 
 This routine is configured via Anthropic Routines
 (<https://code.claude.com/docs/en/routines>, research preview) and runs
 as a normal Claude Code cloud session. The routine prompt below is the
-user turn; Verdict's `Stop` hook fires normally when the session ends.
+user turn; Proofloop's `Stop` hook fires normally when the session ends.
 
 ## Setup
 
 1. Open <https://claude.ai/code/routines> (or run `/schedule weekly
-   Verdict team digest` from any Claude Code session).
+   Proofloop team digest` from any Claude Code session).
 2. Attach the repository or repositories whose `skills/judge/scores/`
    directory you want summarised.
 3. Select the Slack connector so the routine can post the digest.
@@ -24,7 +24,7 @@ user turn; Verdict's `Stop` hook fires normally when the session ends.
 ## Routine prompt
 
 ```
-You are the Verdict weekly digest bot.
+You are the Proofloop weekly digest bot.
 
 1. List every JSON file in skills/judge/scores/ whose timestamp falls
    in the last 7 calendar days. For each file, load the JSON and note
@@ -60,7 +60,7 @@ Stop the session once the digest is posted. No code changes.
   channel membership and repo permissions accordingly.
 - Pro users get 5 routine runs/day, Max 15, Team/Enterprise 25 — the
   weekly schedule is well within all plans.
-- Verdict's `Stop` hook fires in the routine's session just as it would
+- Proofloop's `Stop` hook fires in the routine's session just as it would
   in an interactive one, and the scorecard JSON is committed on branches
   prefixed with `claude/` by default (toggle **Allow unrestricted branch
   pushes** if you prefer direct pushes to `main`).

--- a/schemas/scorecard.v1.schema.json
+++ b/schemas/scorecard.v1.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://verdict.dev/schemas/scorecard.v1.json",
-  "title": "Verdict Scorecard",
-  "description": "Canonical shape of a Verdict scorecard JSON document as emitted by skills/judge/scripts/score.py::save_score. See DEEP_ANALYSIS.md §Schema stability contract for evolution rules.",
+  "$id": "https://proofloop.dev/schemas/scorecard.v1.json",
+  "title": "Proofloop Scorecard",
+  "description": "Canonical shape of a Proofloop scorecard JSON document as emitted by skills/judge/scripts/score.py::save_score. See DEEP_ANALYSIS.md §Schema stability contract for evolution rules.",
   "type": "object",
   "required": [
     "$schema",
@@ -27,7 +27,7 @@
   "properties": {
     "$schema": {
       "type": "string",
-      "const": "https://verdict.dev/schemas/scorecard.v1.json"
+      "const": "https://proofloop.dev/schemas/scorecard.v1.json"
     },
     "schemaVersion": {
       "type": "string",

--- a/scripts/bench_lint.py
+++ b/scripts/bench_lint.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Benchmark task-hygiene lint for the Verdict regression-gate corpus.
+"""Benchmark task-hygiene lint for the Proofloop regression-gate corpus.
 
 Adapts the Auto Benchmark Audit (ABA) framework (Wang et al. 2026,
 arXiv:2605.26079, "Automated Benchmark Auditing for AI Agents and
-Large Language Models", v1 2026-05-25) to Verdict's transcript-
+Large Language Models", v1 2026-05-25) to Proofloop's transcript-
 regression manifest. ABA was designed for *task* benchmarks with
-ground-truth outputs; Verdict's benchmark pack scores transcripts
+ground-truth outputs; Proofloop's benchmark pack scores transcripts
 against expected score bounds rather than tasks against expected
 answers. The four ABA issue classes map by analogy:
 
@@ -44,7 +44,7 @@ DEFAULT_MANIFEST = PROJECT_ROOT / "benchmarks" / "manifest.json"
 DEFAULT_THRESHOLD = 0.85
 TOOL_NAME = "verdict-bench-lint"
 TOOL_VERSION = "2.0.3"
-TOOL_URI = "https://github.com/sattyamjjain/verdict"
+TOOL_URI = "https://github.com/sattyamjjain/proofloop"
 
 # Adapter -> set of allowed file suffixes. Used by VBL002 to flag
 # obvious mismatches such as adapter "openai-compatible" pointing at a
@@ -320,7 +320,7 @@ def render_text(report: Dict[str, Any], threshold: float) -> str:
     flagged = report["flagged_cases"]
     verdict = "PASS" if score >= threshold else "FAIL"
     lines.append("┌" + "─" * width + "┐")
-    lines.append(row("  VERDICT BENCH-LINT (ABA-anchored, arXiv:2605.26079)"))
+    lines.append(row("  PROOFLOOP BENCH-LINT (ABA-anchored, arXiv:2605.26079)"))
     lines.append("├" + "─" * width + "┤")
     lines.append(row(f"  Manifest: {Path(report['manifest']).name}"))
     lines.append(row(f"  Cases:    {total} total, {flagged} flagged"))
@@ -423,7 +423,7 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="bench_lint",
         description=(
-            "ABA-anchored task-hygiene lint for Verdict's benchmark pack. "
+            "ABA-anchored task-hygiene lint for Proofloop's benchmark pack. "
             "Offline, stdlib-only, no LLM call."
         ),
     )

--- a/scripts/install_rubric.py
+++ b/scripts/install_rubric.py
@@ -2,13 +2,13 @@
 """Install a community rubric from a URL.
 
 Fetches a rubric markdown file (and optional ``.weights.json`` sidecar)
-from a GitHub raw URL or any HTTPS URL, validates it looks like a Verdict
+from a GitHub raw URL or any HTTPS URL, validates it looks like a Proofloop
 rubric, and drops it into ``skills/judge/rubrics/``. Stdlib-only.
 
 Usage:
     python3 scripts/install_rubric.py <url> [--name NAME] [--rubric-dir DIR]
 
-The rubric file must contain the Verdict dimension table (``### Correctness``,
+The rubric file must contain the Proofloop dimension table (``### Correctness``,
 etc.) — any document missing that structure is rejected. If the URL's
 directory also contains ``<name>.weights.json``, it is fetched and
 validated via ``score.load_rubric_weights``.
@@ -48,7 +48,7 @@ def _fetch(url: str, timeout: int = 10) -> Optional[bytes]:
 
 
 def _validate_rubric_text(text: str) -> Optional[str]:
-    """Return an error message if *text* is not a Verdict rubric, else None."""
+    """Return an error message if *text* is not a Proofloop rubric, else None."""
     missing = [h for h in REQUIRED_HEADINGS if h not in text]
     if missing:
         return f"rubric is missing required headings: {missing}"

--- a/scripts/sandbox_caps_check.py
+++ b/scripts/sandbox_caps_check.py
@@ -2,7 +2,7 @@
 """Sandbox-capability declaration check for the self-score CI gate.
 
 Claude Code v2.1.117 (Apr 2026) hardened its sandbox: ``bash`` and
-file-write are now namespace-isolated. CI workflows that run Verdict
+file-write are now namespace-isolated. CI workflows that run Proofloop
 under that sandbox declare the caps they intend to use via the
 ``CLAUDE_SANDBOX_CAPS`` env var. This script reads that var, parses
 the cap list, and asserts the declaration is present.

--- a/skills/judge/SKILL-judge-explain.md
+++ b/skills/judge/SKILL-judge-explain.md
@@ -1,6 +1,6 @@
 ---
 name: judge-explain
-description: "Render a Verdict scorecard JSON as PR-friendly Markdown or stable-schema JSON"
+description: "Render a Proofloop scorecard JSON as PR-friendly Markdown or stable-schema JSON"
 ---
 
 # `/judge --explain` — Scorecard Rationale Exporter
@@ -17,9 +17,9 @@ two formats:
 
 ## Why
 
-Verdict scorecards already carry every signal needed to justify the
+Proofloop scorecards already carry every signal needed to justify the
 composite score. Adopters asked
-([Discussions #43](https://github.com/sattyamjjain/verdict/discussions/43))
+([Discussions #43](https://github.com/sattyamjjain/proofloop/discussions/43))
 for a one-shot way to drop the rationale into PR conversations
 without copy-pasting from the raw JSON. `/judge --explain` is that
 shot.
@@ -39,7 +39,7 @@ scorecard is missing or malformed.
 ## Markdown output shape
 
 ```markdown
-# Verdict Scorecard — `<skill>`
+# Proofloop Scorecard — `<skill>`
 
 **Composite:** <score>/10 — **Grade:** <letter> (<label>)
 **Rubric:** `<rubric>` · **Model:** `<model>` · **Timestamp:** `<ISO-8601>`
@@ -132,7 +132,7 @@ introduction.
   recorded. The `evidence` block surfaces the counts so a reviewer
   can gauge signal volume. Storing the matched spans is queued for
   v1.4.0.
-- **No cost telemetry.** Verdict doesn't track API usage today, so
+- **No cost telemetry.** Proofloop doesn't track API usage today, so
   the explain output omits a cost field. When the LLM second-opinion
   path adds usage tracking, an `usage` block joins the schema as
   `explain.v1.1`.

--- a/skills/judge/SKILL.md
+++ b/skills/judge/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: judge
-displayName: "Verdict — Universal Quality Evaluator"
+displayName: "Proofloop — Universal Quality Evaluator"
 description: "Evaluates the execution quality of any skill or agent using 7-dimension scoring with configurable rubrics"
-version: "2.0.8"
+version: "3.0.0"
 author: "Sattyam Jain"
 allowed-tools: [Read, Write, Edit, Bash]
 autoActivate:
@@ -11,13 +11,13 @@ autoActivate:
   - "when referenced by /judge command"
 ---
 
-# Verdict — Universal Quality Evaluator
+# Proofloop — Universal Quality Evaluator
 
 ## Overview
 
-Verdict is a universal quality evaluator for Claude Code skills and agents. It measures execution quality across 7 weighted dimensions, producing an evidence-based scorecard with letter grades, justifications, and actionable recommendations.
+Proofloop is a universal quality evaluator for Claude Code skills and agents. It measures execution quality across 7 weighted dimensions, producing an evidence-based scorecard with letter grades, justifications, and actionable recommendations.
 
-Verdict operates in two modes:
+Proofloop operates in two modes:
 
 - **Auto Mode**: Hooks into skill/agent lifecycle events (e.g. `Stop`) and automatically evaluates every execution. No user intervention required. Scores are persisted to `skills/judge/scores/` for trend analysis.
 - **Manual Mode**: Triggered explicitly via the `/judge` command. The user specifies a skill name and optionally a transcript path. Useful for on-demand evaluation, re-scoring, or benchmarking.
@@ -28,7 +28,7 @@ Both modes produce the same structured scorecard output.
 
 ## Scoring Dimensions
 
-Verdict evaluates across 7 dimensions. Each dimension receives a score from 1.0 to 10.0. The weighted composite determines the final grade.
+Proofloop evaluates across 7 dimensions. Each dimension receives a score from 1.0 to 10.0. The weighted composite determines the final grade.
 
 | #  | Dimension        | Weight | What It Measures                                                                 |
 |----|------------------|--------|----------------------------------------------------------------------------------|
@@ -136,7 +136,7 @@ Every evaluation produces a visual scorecard rendered in the terminal:
 
 ```
 ╔═══════════════════════════════════════════════════════════╗
-║  VERDICT SCORECARD — {skill-name}                      ║
+║  PROOFLOOP SCORECARD — {skill-name}                      ║
 ╠═══════════════════════════════════════════════════════════╣
 ║  Correctness    ████████░░  8.0/10  {justification}       ║
 ║  Completeness   ██████░░░░  6.0/10  {justification}       ║
@@ -160,7 +160,7 @@ The progress bars use filled blocks (█) and empty blocks (░) proportional to
 
 ### Auto Mode
 
-When auto mode is enabled, Verdict hooks into the `Stop` lifecycle event. After any skill or agent finishes execution, the hook script:
+When auto mode is enabled, Proofloop hooks into the `Stop` lifecycle event. After any skill or agent finishes execution, the hook script:
 
 1. Captures the session transcript
 2. Invokes the judge-agent as an isolated subagent
@@ -207,7 +207,7 @@ To add a custom rubric, copy `custom-template.md` and rename it to match your sk
 
 ## Instructions for Claude — How to Perform an Evaluation
 
-When you are activated as the Verdict evaluator (either via auto hook or `/judge` command), follow these instructions precisely:
+When you are activated as the Proofloop evaluator (either via auto hook or `/judge` command), follow these instructions precisely:
 
 ### 1. Gather Context
 
@@ -309,7 +309,7 @@ Write the JSON scorecard to `skills/judge/scores/{skill-name}-{YYYYMMDD-HHMMSS}.
 - **Non-Claude transcript** (Codex, Cursor, Continue, OpenAI-compatible):
   Use `score.py --adapter NAME` to extract lines via the matching
   adapter in `skills/judge/adapters/`.
-- **Evaluation of Verdict itself**: This is allowed. Apply the same
+- **Evaluation of Proofloop itself**: This is allowed. Apply the same
   process without bias.
 
 ---

--- a/skills/judge/adapters/claude_code.py
+++ b/skills/judge/adapters/claude_code.py
@@ -3,7 +3,7 @@
 Claude Code and Cowork write transcripts as JSONL, one record per line.
 Records include ``{"role": "...", "content": "..."}`` for user /
 assistant turns and ``{"type": "tool_use", ...}`` or similar for tool
-calls. This is Verdict's reference format — extraction is a lightweight
+calls. This is Proofloop's reference format — extraction is a lightweight
 re-expression of ``score.load_transcript`` that stays adapter-agnostic.
 
 Auto Memory (Opus 4.7, 2026-04-17+)
@@ -13,7 +13,7 @@ plus a memory preamble that Claude Code injects at the top of every
 new session. To handle that, ``extract_lines`` accepts EITHER a file
 path OR a directory:
 
-- **File**: behaviour identical to pre-1.2 Verdict.
+- **File**: behaviour identical to pre-1.2 Proofloop.
 - **Directory**: enumerate ``*.jsonl`` sorted by mtime (oldest first),
   concatenate the extracted lines, and inject a ``--- session break ---``
   marker between files so downstream heuristics can attribute signals
@@ -31,7 +31,7 @@ Parallel sub-agents share state through a server-managed memory
 endpoint. Claude Code streams synthetic records into the JSONL
 transcript whenever a managed sub-agent reads from or writes to the
 shared store. These records carry tokens like ``managed_memory_v1``,
-``agent_memory``, or ``parent_agent_id``. Verdict tags pull events
+``agent_memory``, or ``parent_agent_id``. Proofloop tags pull events
 with ``[managed-memory-pull]`` and push events with
 ``[managed-memory-push]`` so the scoring engine can tell apart first-
 party reasoning from memory stitching.

--- a/skills/judge/analyzers/__init__.py
+++ b/skills/judge/analyzers/__init__.py
@@ -4,7 +4,7 @@ v1.2.0+ adds ``llm_judge``, an opt-in second-opinion path that calls
 Claude (default ``claude-haiku-4-5``) to produce dimension scores
 alongside the default heuristic output. Gated by
 ``judge-config.json.llm_second_opinion.enabled`` — off by default so
-Verdict's offline-first promise is preserved.
+Proofloop's offline-first promise is preserved.
 """
 from __future__ import annotations
 

--- a/skills/judge/analyzers/llm_judge.py
+++ b/skills/judge/analyzers/llm_judge.py
@@ -26,7 +26,7 @@ Cross-family second-opinion pattern note (2026-05-09): GitHub
 Copilot CLI's Rubber Duck (cross-family critic, expanded model
 pairings shipped 2026-05-07) is the same pattern this analyzer
 implements: an opt-in second model from a different family reviews
-the first model's output. Verdict runs this off-by-default and
+the first model's output. Proofloop runs this off-by-default and
 stdlib-only; the critic is one signal among many, NOT a leaderboard
 verdict. Source:
 https://github.blog/changelog/2026-05-07-rubber-duck-in-github-copilot-cli-now-supports-more-models/
@@ -81,12 +81,12 @@ TASK_BUDGETS_BETA_LEGACY = "task-budgets-2026-03-13"
 # Minimum total tokens the task_budgets header accepts (per docs).
 TASK_BUDGET_MIN_TOKENS: int = 20_000
 # Hard ceiling multiplier: task_budget is a soft suggestion; the
-# ``max_tokens`` request parameter is the hard cap. Verdict sets both
+# ``max_tokens`` request parameter is the hard cap. Proofloop sets both
 # so the judge finishes gracefully without over-spend.
 TASK_BUDGET_HARD_CEILING_RATIO: float = 1.25
 
 # Prompt-caching (Apr 2026). Claude Code's changelog enables caching by
-# default; Verdict mirrors that. TTLs: "5m" is stock; "1h" requires the
+# default; Proofloop mirrors that. TTLs: "5m" is stock; "1h" requires the
 # extended-cache-ttl-2025-04-11 beta header. Env vars flip the knob
 # without touching judge-config.json so CI can set them on a hot path.
 EXTENDED_CACHE_TTL_BETA: str = "extended-cache-ttl-2025-04-11"
@@ -96,7 +96,7 @@ ENV_FORCE_CACHE_5M: str = "FORCE_PROMPT_CACHING_5M"
 
 
 def resolve_cache_ttl_from_env(env: Optional[Dict[str, str]] = None) -> str:
-    """Pick a prompt-cache TTL from Verdict's env-var convention.
+    """Pick a prompt-cache TTL from Proofloop's env-var convention.
 
     Precedence: ``FORCE_PROMPT_CACHING_5M`` (explicit lock-down) >
     ``ENABLE_PROMPT_CACHING_1H`` (extended beta) > default ``"5m"``.
@@ -154,7 +154,7 @@ class LLMClient(Protocol):
 class AnthropicClient:
     """Minimal stdlib-only Anthropic API client.
 
-    Only implements the single ``messages_create`` call Verdict needs.
+    Only implements the single ``messages_create`` call Proofloop needs.
     Adds the ``task-budgets-2026-03-13`` beta header when a budget is
     configured so Claude self-caps runaway evaluations.
     """
@@ -196,7 +196,7 @@ class AnthropicClient:
         # task_budget is a hint that lets Claude finish mid-sentence
         # when it's close to done; max_tokens is the model-side cap.
         # Per Anthropic docs (2026-04-20): total is soft, max_tokens
-        # is hard. Verdict sets both so the judge finishes gracefully
+        # is hard. Proofloop sets both so the judge finishes gracefully
         # without over-spend.
         body: Dict[str, Any] = {
             "model": model,
@@ -271,7 +271,7 @@ def _log_cache_usage(response: Dict[str, Any], model: str) -> None:
     Reads ``usage.cache_read_input_tokens`` (hit) and
     ``usage.cache_creation_input_tokens`` (miss) from the Messages API
     response. Silent when neither field is present — pre-caching hosts
-    won't return them and Verdict shouldn't log noise.
+    won't return them and Proofloop shouldn't log noise.
     """
     usage = response.get("usage")
     if not isinstance(usage, dict):
@@ -351,12 +351,12 @@ def _rubric_criteria_summary(rubric: Dict[str, Any]) -> str:
 #     +25pp vs. human-aligned baselines.
 #   * Role-relabel attacks (arXiv:2606.05976): framing the same output
 #     as the judge's own work swings scores +23-93pp.
-# So when Verdict's second-opinion judge shares a model family with the
+# So when Proofloop's second-opinion judge shares a model family with the
 # model that produced the transcript, the second opinion is structurally
 # biased *upward* and should be flagged (and, where a cross-family judge
 # is configured, swapped out).
 #
-# Verdict's executing-model detector (`score.detect_model_from_transcript`)
+# Proofloop's executing-model detector (`score.detect_model_from_transcript`)
 # only recognises `claude-*` today, and the default judge is Claude — so
 # in the stock configuration this guard fires on every enabled run, which
 # is the honest signal: Claude-judging-Claude is self-preference-prone.
@@ -455,7 +455,7 @@ def same_family_guard(
 
 
 SYSTEM_PROMPT = (
-    "You are Verdict's second-opinion judge. Score the transcript on the "
+    "You are Proofloop's second-opinion judge. Score the transcript on the "
     "seven dimensions below, each on a 1-10 integer scale. Reply with a "
     "single JSON object mapping each dimension name to "
     '{"score": <int 1-10>, "justification": "<one sentence>"}. '

--- a/skills/judge/rubrics/default.md
+++ b/skills/judge/rubrics/default.md
@@ -97,7 +97,7 @@ existing low-variance branch from rewarding a collapsed verifier (it
 would otherwise grant a `+1` "highly consistent" bonus to the same
 data that triggers the dock). Pure stdlib statistics; no LLM call.
 Configurable via `judge-config.json.verifier_collapse` (set
-`enabled: false` to disable). Derived from Verdict's own consistency
+`enabled: false` to disable). Derived from Proofloop's own consistency
 dimension plus the Soft-SVeRL project anchor — distinct from
 variance-based consistency, not a sibling analogy.
 

--- a/skills/judge/scripts/against.py
+++ b/skills/judge/scripts/against.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Compare two Verdict scorecards and render a delta report.
+"""Compare two Proofloop scorecards and render a delta report.
 
 Powers ``/judge --against HEAD~1`` (and the more general
 ``--against <timestamp>``): picks two scorecards for the same skill and
@@ -59,7 +59,7 @@ def _pad(value: str, width: int) -> str:
 def render(baseline: Dict[str, Any], target: Dict[str, Any]) -> str:
     """Return a Unicode table summarising the delta between two scorecards."""
     lines: List[str] = []
-    header = f"Verdict delta: {target.get('skill', '?')}"
+    header = f"Proofloop delta: {target.get('skill', '?')}"
     lines.append("╭" + "─" * (len(header) + 2) + "╮")
     lines.append(f"│ {header} │")
     lines.append("╰" + "─" * (len(header) + 2) + "╯")
@@ -84,11 +84,11 @@ def render(baseline: Dict[str, Any], target: Dict[str, Any]) -> str:
     lines.append(f"{_pad('composite', 15)} {baseline.get('composite_score', 0):>7.2f}  {target.get('composite_score', 0):>7.2f}  {composite_delta:>+6.2f} {_arrow(composite_delta)}")
     lines.append("")
     if composite_delta > 0.05:
-        lines.append(f"Verdict: IMPROVED (+{composite_delta:.2f})")
+        lines.append(f"Proofloop: IMPROVED (+{composite_delta:.2f})")
     elif composite_delta < -0.05:
-        lines.append(f"Verdict: REGRESSED ({composite_delta:+.2f})")
+        lines.append(f"Proofloop: REGRESSED ({composite_delta:+.2f})")
     else:
-        lines.append("Verdict: FLAT")
+        lines.append("Proofloop: FLAT")
     return "\n".join(lines)
 
 

--- a/skills/judge/scripts/benchmark.py
+++ b/skills/judge/scripts/benchmark.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verdict Benchmark Comparator.
+"""Proofloop Benchmark Comparator.
 
 Compares a skill's historical scores against benchmark standards and identifies
 strengths, weaknesses, and specific improvement suggestions.
@@ -423,7 +423,7 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
         prog="benchmark",
-        description="Verdict Benchmark Comparator -- compare scores against benchmark standards.",
+        description="Proofloop Benchmark Comparator -- compare scores against benchmark standards.",
     )
     parser.add_argument(
         "--skill",

--- a/skills/judge/scripts/cost_estimator.py
+++ b/skills/judge/scripts/cost_estimator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Local-only per-scorecard cost estimator (R4).
 
-Estimates the USD cost of running Verdict's opt-in LLM second-opinion
+Estimates the USD cost of running Proofloop's opt-in LLM second-opinion
 analyzer for a given scorecard, based on a stdlib-only per-model
 pricing table. **Local-only** — no SaaS coupling, no telemetry leaves
 the host. Pricing is a starting point; adopters override via
@@ -24,7 +24,7 @@ The scorecard path mode reads ``adjustments.brier_calibration`` /
 ``llm_usage`` block; cost is reported per-scorecard.
 
 Stdlib-only. No third-party deps. The pricing table reflects
-April 2026 published rates for the most common models Verdict's
+April 2026 published rates for the most common models Proofloop's
 LLM-judge path uses; figures are USD per 1M tokens.
 """
 from __future__ import annotations
@@ -132,7 +132,7 @@ def estimate_from_scorecard(
     - ``llm_usage.input_tokens`` / ``llm_usage.output_tokens`` when
       the LLM second-opinion analyzer ran and recorded usage. When
       absent, returns a "no LLM usage recorded" rationale and zero
-      cost — Verdict's heuristic-only path is free.
+      cost — Proofloop's heuristic-only path is free.
     """
     target = Path(scorecard_path)
     if not target.is_file():
@@ -151,7 +151,7 @@ def estimate_from_scorecard(
             "skill": card.get("skill"),
             "model_lookup": model,
             "rationale": (
-                "No llm_usage block — Verdict ran heuristics only "
+                "No llm_usage block — Proofloop ran heuristics only "
                 "(zero LLM cost)."
             ),
             "total_usd": 0.0,
@@ -170,7 +170,7 @@ def estimate_from_scorecard(
 
 
 def parse_args(argv: Optional[list] = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(prog="verdict-cost-estimator")
+    parser = argparse.ArgumentParser(prog="proofloop-cost-estimator")
     parser.add_argument(
         "--input-tokens", type=int, default=None,
         help="Input token count for direct estimate. Pair with --model.",
@@ -204,18 +204,18 @@ def main(argv: Optional[list] = None) -> int:
     try:
         pricing = load_pricing(args.pricing_file)
     except (FileNotFoundError, ValueError) as exc:
-        print(f"verdict-cost-estimator: {exc}", file=sys.stderr)
+        print(f"proofloop-cost-estimator: {exc}", file=sys.stderr)
         return 2
     if args.scorecard:
         try:
             result = estimate_from_scorecard(args.scorecard, pricing)
         except (FileNotFoundError, ValueError) as exc:
-            print(f"verdict-cost-estimator: {exc}", file=sys.stderr)
+            print(f"proofloop-cost-estimator: {exc}", file=sys.stderr)
             return 2
     elif args.input_tokens is not None or args.output_tokens is not None:
         if args.model is None:
             print(
-                "verdict-cost-estimator: --model required for direct estimate",
+                "proofloop-cost-estimator: --model required for direct estimate",
                 file=sys.stderr,
             )
             return 2
@@ -227,11 +227,11 @@ def main(argv: Optional[list] = None) -> int:
                 pricing,
             )
         except ValueError as exc:
-            print(f"verdict-cost-estimator: {exc}", file=sys.stderr)
+            print(f"proofloop-cost-estimator: {exc}", file=sys.stderr)
             return 2
     else:
         print(
-            "verdict-cost-estimator: provide --scorecard OR "
+            "proofloop-cost-estimator: provide --scorecard OR "
             "(--input-tokens + --output-tokens + --model)",
             file=sys.stderr,
         )

--- a/skills/judge/scripts/detect-skill.sh
+++ b/skills/judge/scripts/detect-skill.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Verdict — Detect which skill was used from a transcript
+# Proofloop — Detect which skill was used from a transcript
 # Delegates to the shared detect_skill_from_transcript() in common.sh
 set -euo pipefail
 

--- a/skills/judge/scripts/explain.py
+++ b/skills/judge/scripts/explain.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verdict scorecard rationale exporter.
+"""Proofloop scorecard rationale exporter.
 
 Reads an existing scorecard JSON written by ``score.py`` and renders a
 PR-comment-friendly Markdown explanation OR a stable-schema JSON
@@ -29,7 +29,7 @@ Usage:
 Writes to stdout when ``--out`` is omitted.
 
 Source signal: GitHub Discussions #43 — top adopter ask "explain my
-scorecard" (https://github.com/sattyamjjain/verdict/discussions/43).
+scorecard" (https://github.com/sattyamjjain/proofloop/discussions/43).
 """
 from __future__ import annotations
 
@@ -43,7 +43,7 @@ EXPLAIN_FORMAT_VERSION: str = "explain.v1"
 HTML_FORMAT_VERSION: str = "explain.html.v1"
 
 # GitHub PR-comment hard cap is 65,536 chars; the Markdown render must
-# stay below that or the auto-comment step in `actions/verdict-comment-pr`
+# stay below that or the auto-comment step in `actions/proofloop-comment-pr`
 # silently truncates. Default cap leaves headroom for a comment header
 # the action prepends. Override with --max-evidence-chars.
 DEFAULT_MAX_EVIDENCE_CHARS: int = 4000
@@ -259,7 +259,7 @@ def render_html_printable(
     timestamp = card.get("timestamp", "?")
     summary = (card.get("summary") or "").strip()
     one_liner = (card.get("one_liner") or "").strip()
-    title = cover_title or f"{skill} — Verdict Scorecard"
+    title = cover_title or f"{skill} — Proofloop Scorecard"
 
     entries = _ordered_dimension_entries(card)
     strengths = sorted(entries, key=lambda e: -e.get("score", 0))[:3]
@@ -336,7 +336,7 @@ def render_html_printable(
             f'<h2>Signature</h2>'
             f'<p>Signed by: <strong>{_html_escape(signer)}</strong></p>'
             f'<p>Date: <strong>{_html_escape(timestamp)}</strong></p>'
-            f'<p>Verdict format version: '
+            f'<p>Proofloop format version: '
             f'<code>{HTML_FORMAT_VERSION}</code></p>'
             f'</section>'
         )
@@ -444,7 +444,7 @@ td.just {{ font-size: 0.92em; color: #333; }}
 
 <section class="page-break appendix">
     <h2>Methodology appendix</h2>
-    <p>Verdict scores agent transcripts on seven canonical dimensions
+    <p>Proofloop scores agent transcripts on seven canonical dimensions
        (correctness, completeness, adherence, actionability,
        efficiency, safety, consistency). Per-rubric weight overrides
        are applied via a sidecar <code>&lt;rubric&gt;.weights.json</code>.</p>
@@ -453,7 +453,7 @@ td.just {{ font-size: 0.92em; color: #333; }}
         <li>Weights source: <code>{_html_escape(card.get("weights_source", "config"))}</code></li>
         <li>Tokenizer baseline: <code>{_html_escape(card.get("tokenizer_baseline", 1.0))}</code></li>
         <li>Transcript lines analysed: {_html_escape(transcript_lines)}</li>
-        <li>Verdict format version: <code>{HTML_FORMAT_VERSION}</code></li>
+        <li>Proofloop format version: <code>{HTML_FORMAT_VERSION}</code></li>
     </ul>
 </section>
 
@@ -517,7 +517,7 @@ def _md_verifier_collapse_callout(card: Dict[str, Any]) -> Optional[str]:
         "window of recent scorecards for this skill shows the "
         "judge/verifier has flatlined at the top of the scale — a "
         "failure mode distinct from low score variance, derived from "
-        "Verdict's own consistency dimension plus the Soft-SVeRL "
+        "Proofloop's own consistency dimension plus the Soft-SVeRL "
         "signal.",
         "",
         f"- **Reason:** {reason}",
@@ -545,7 +545,7 @@ def render_markdown(card: Dict[str, Any]) -> str:
     summary = card.get("summary", "").strip()
 
     header = (
-        f"# Verdict Scorecard — `{skill}`\n\n"
+        f"# Proofloop Scorecard — `{skill}`\n\n"
         f"**Composite:** {composite}/10 — **Grade:** {grade}"
         f"{(' (' + grade_label + ')') if grade_label else ''}  \n"
         f"**Rubric:** `{rubric}` · **Model:** `{model}` · "
@@ -619,8 +619,8 @@ def render_markdown(card: Dict[str, Any]) -> str:
 
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        prog="verdict-explain",
-        description="Render a Verdict scorecard JSON as Markdown or JSON.",
+        prog="proofloop-explain",
+        description="Render a Proofloop scorecard JSON as Markdown or JSON.",
     )
     parser.add_argument(
         "--scorecard", required=True,
@@ -638,7 +638,7 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--cover",
         help="Cover-page title for --format html-printable. Defaults to "
-             "'<skill> — Verdict Scorecard'.",
+             "'<skill> — Proofloop Scorecard'.",
     )
     parser.add_argument(
         "--signer",
@@ -672,7 +672,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     try:
         card = load_scorecard(Path(args.scorecard))
     except ValueError as exc:
-        print(f"verdict-explain: {exc}", file=sys.stderr)
+        print(f"proofloop-explain: {exc}", file=sys.stderr)
         return 2
     if args.format == "md":
         rendered = render_markdown(card)

--- a/skills/judge/scripts/report.py
+++ b/skills/judge/scripts/report.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verdict Score Reporter.
+"""Proofloop Score Reporter.
 
 Reads persisted score JSON files and produces visual scorecards with
 Unicode bar charts, trend indicators, and historical averages.
@@ -156,7 +156,7 @@ def render_text_scorecard(record: Dict[str, Any], history: List[Dict[str, Any]])
     lines.append(_horizontal_rule(BOX_TL, BOX_TR))
 
     # Header
-    header = f"VERDICT SCORECARD -- {skill}"
+    header = f"PROOFLOOP SCORECARD -- {skill}"
     lines.append(_pad_line(header))
     lines.append(_pad_line(f"Grade: {grade} ({grade_label})  |  Composite: {composite}/10.0  |  {timestamp}"))
     lines.append(_horizontal_rule(BOX_ML, BOX_MR))
@@ -300,7 +300,7 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
         prog="report",
-        description="Verdict Score Reporter -- view scorecards, trends, and averages.",
+        description="Proofloop Score Reporter -- view scorecards, trends, and averages.",
     )
     parser.add_argument(
         "--scores-dir",

--- a/skills/judge/scripts/score.py
+++ b/skills/judge/scripts/score.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verdict Scoring Engine.
+"""Proofloop Scoring Engine.
 
 Evaluates Claude Code / Cowork skill and agent executions across 7 weighted
 dimensions, producing a composite score and letter grade.  Designed to run
@@ -392,7 +392,7 @@ def load_rubric_weights(
 ) -> Optional[Dict[str, float]]:
     """Return per-rubric weight overrides from ``<rubric>.weights.json`` or None.
 
-    The sidecar must contain a JSON object mapping each of Verdict's seven
+    The sidecar must contain a JSON object mapping each of Proofloop's seven
     dimensions to a float; the sum must equal 1.0 within
     ``WEIGHT_SUM_TOLERANCE``. Any other shape emits a stderr warning and
     returns None so the caller falls back to the global config.
@@ -1020,7 +1020,7 @@ DISCUSSION_CONTEXT = re.compile(
 #
 # Plugin-author transcripts that legitimately edit these paths should
 # not accumulate safety-dimension hits for non-destructive operations.
-# Catastrophic removal commands still prompt at the runtime, and verdict
+# Catastrophic removal commands still prompt at the runtime, and Proofloop
 # mirrors that: destructive shell forms (``rm -rf``, ``chmod 777``,
 # ``sudo rm``, raw ``DROP TABLE`` / ``TRUNCATE TABLE``, ``eval(``,
 # ``exec(``) on these paths STILL dock the safety dimension.
@@ -1028,7 +1028,7 @@ DISCUSSION_CONTEXT = re.compile(
 # The shell-config-file set is intentionally closed to the standard
 # POSIX / zsh login files. We do NOT glob ``.*rc`` — that would
 # tolerate writes to ``.npmrc`` (npm credentials) or ``.dockerrc``
-# (registry creds), which is a real exfil-risk class verdict should
+# (registry creds), which is a real exfil-risk class Proofloop should
 # NOT excuse. Source: <https://code.claude.com/docs/en/changelog> §v2.1.126.
 _CLAUDE_PLUGIN_PATH_RE = re.compile(
     # .claude/ subtree (any depth), .git/ subtree, .vscode/ subtree.
@@ -1342,7 +1342,7 @@ def _detect_verifier_collapse(
     scored by :func:`_analyze_consistency`, which would otherwise
     *reward* the failure mode with a low-std_dev bonus. The detector
     here composes with that logic by adding an explicit dock when both
-    criteria hit, derived from Verdict's own consistency dimension plus
+    criteria hit, derived from Proofloop's own consistency dimension plus
     the project-anchor "Soft-SVeRL" signal.
 
     Returns a dict with::
@@ -1652,7 +1652,7 @@ def detect_bonuses(transcript_lines: List[str]) -> List[str]:
 # Scores agreement-drift across turns: does the assistant abandon a prior
 # answer under user pressure ("are you sure? I think it's X") purely to
 # agree, rather than because it was actually wrong. This is response-
-# quality (truthfulness under pressure), overlapping Verdict's existing
+# quality (truthfulness under pressure), overlapping Proofloop's existing
 # correctness/consistency dimensions — NOT a new rubric and NOT the
 # trajectory-injection (2606.04778) or role-routing (self-preference)
 # signals. Heuristic and offline by default; the existing opt-in LLM
@@ -1990,7 +1990,7 @@ def _generate_recommendations(dimensions: Dict[str, Dict[str, Any]]) -> List[str
 # Score persistence
 # ---------------------------------------------------------------------------
 
-SCORECARD_SCHEMA_URL: str = "https://verdict.dev/schemas/scorecard.v1.json"
+SCORECARD_SCHEMA_URL: str = "https://proofloop.dev/schemas/scorecard.v1.json"
 SCORECARD_SCHEMA_VERSION: str = "1.0.0"
 
 
@@ -2000,7 +2000,7 @@ def _llm_second_opinion_config(config: Dict[str, Any]) -> Dict[str, Any]:
     Defaults: disabled, Haiku 4.5, no explicit budget. Callers should
     treat a missing or malformed block as "disabled" without warning.
     ``task_budget_tokens`` (2026-04-20+) is the ``task_budgets-2026-03-13``
-    beta-header soft cap — passed through when the caller lets Verdict
+    beta-header soft cap — passed through when the caller lets Proofloop
     construct the default AnthropicClient.
     """
     block = config.get("llm_second_opinion") if isinstance(config, dict) else None
@@ -2036,7 +2036,7 @@ def _maybe_llm_second_opinion(
 
     No-op (returns ``None``) when the config block has ``enabled=false``
     (the default). Failures (missing API key, HTTP error, unparseable
-    response) are logged to stderr and swallowed — Verdict must stay
+    response) are logged to stderr and swallowed — Proofloop must stay
     offline-first, so a busted LLM path can never fail the whole
     scorecard.
 
@@ -2076,7 +2076,7 @@ def _maybe_llm_second_opinion(
     judge_model = cfg["model"]
     if guard["self_preference_risk"]:
         print(
-            f"Verdict WARNING: {guard['reason']} "
+            f"Proofloop WARNING: {guard['reason']} "
             f"(executing={guard['executing_family']}, "
             f"judge={guard['judge_family']}:{cfg['model']})",
             file=sys.stderr,
@@ -2084,7 +2084,7 @@ def _maybe_llm_second_opinion(
         if guard["auto_preferred"] and guard["preferred_model"]:
             judge_model = guard["preferred_model"]
             print(
-                f"Verdict: auto-preferring cross-family second-opinion "
+                f"Proofloop: auto-preferring cross-family second-opinion "
                 f"judge {judge_model} ({guard['judge_family']} → "
                 f"{model_family(judge_model)}).",
                 file=sys.stderr,
@@ -2423,7 +2423,7 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
         prog="score",
-        description="Verdict Scoring Engine -- evaluate skill/agent executions across 7 dimensions.",
+        description="Proofloop Scoring Engine -- evaluate skill/agent executions across 7 dimensions.",
     )
     parser.add_argument(
         "--skill",
@@ -2474,7 +2474,7 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         choices=["openai-evals"],
         default=None,
         help=(
-            "Emit a portable scorecard alongside the native Verdict output. "
+            "Emit a portable scorecard alongside the native Proofloop output. "
             "Currently supports 'openai-evals' (OpenAI Model Spec Evals JSON). "
             "Requires --out to specify the destination file."
         ),
@@ -2488,9 +2488,9 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         "--export-rescale",
         action="store_true",
         help=(
-            "When used with --export openai-evals, rescale the 1-10 Verdict "
+            "When used with --export openai-evals, rescale the 1-10 Proofloop "
             "scores into the 1-7 Model Spec bucket. Off by default so the "
-            "numeric score matches downstream Verdict consumers."
+            "numeric score matches downstream Proofloop consumers."
         ),
     )
     return parser.parse_args(argv)

--- a/skills/judge/scripts/studio.py
+++ b/skills/judge/scripts/studio.py
@@ -27,7 +27,7 @@ HTML_TEMPLATE = """<!doctype html>
 <html lang=\"en\">
 <head>
 <meta charset=\"utf-8\" />
-<title>Verdict Studio</title>
+<title>Proofloop Studio</title>
 <style>
   :root {{
     --bg: #0b0d12; --panel: #141820; --ink: #e9edf5;
@@ -69,13 +69,13 @@ HTML_TEMPLATE = """<!doctype html>
 </style>
 </head>
 <body>
-<h1>Verdict Studio</h1>
+<h1>Proofloop Studio</h1>
 <p class=\"tagline\">Auto-generated from {score_count} scorecard(s) across {skill_count} skill(s). Generated {generated_at}.</p>
 <div class=\"grid\">{panels}</div>
 <script>
   // No-op. The HTML is static; this is a placeholder hook for future
   // interactivity (filtering, date-range scrubber, rubric overlay).
-  console.log(\"Verdict Studio loaded with {score_count} scorecards.\");
+  console.log(\"Proofloop Studio loaded with {score_count} scorecards.\");
 </script>
 </body>
 </html>

--- a/skills/judge/scripts/watch.py
+++ b/skills/judge/scripts/watch.py
@@ -6,7 +6,7 @@ seconds via ``os.stat``. When a scorecard's mtime changes:
 
 1. Re-read the scorecard JSON.
 2. Compare each dimension against the previous snapshot.
-3. Emit a single-line diff header + re-render Verdict Studio to
+3. Emit a single-line diff header + re-render Proofloop Studio to
    ``--output``.
 
 Stdlib-only. No file-system watcher dep, no server loop, no threads
@@ -34,7 +34,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent
 sys.path.insert(0, str(PROJECT_ROOT))
 import studio  # noqa: E402
 
-# Seven dimensions Verdict actually tracks.
+# Seven dimensions Proofloop actually tracks.
 DIMENSIONS: List[str] = [
     "correctness", "completeness", "adherence", "actionability",
     "efficiency", "safety", "consistency",

--- a/tests/fixtures/scorecards/code-review__clean-code-review.json
+++ b/tests/fixtures/scorecards/code-review__clean-code-review.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://verdict.dev/schemas/scorecard.v1.json",
+  "$schema": "https://proofloop.dev/schemas/scorecard.v1.json",
   "schemaVersion": "1.0.0",
   "skill": "code-review",
   "timestamp": "2026-04-19T18:59:38Z",

--- a/tests/fixtures/scorecards/code-review__openai-compatible.json
+++ b/tests/fixtures/scorecards/code-review__openai-compatible.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://verdict.dev/schemas/scorecard.v1.json",
+  "$schema": "https://proofloop.dev/schemas/scorecard.v1.json",
   "schemaVersion": "1.0.0",
   "skill": "code-review",
   "timestamp": "2026-04-19T18:59:38Z",

--- a/tests/fixtures/scorecards/code-review__safety-discussion.json
+++ b/tests/fixtures/scorecards/code-review__safety-discussion.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://verdict.dev/schemas/scorecard.v1.json",
+  "$schema": "https://proofloop.dev/schemas/scorecard.v1.json",
   "schemaVersion": "1.0.0",
   "skill": "code-review",
   "timestamp": "2026-04-19T18:59:38Z",

--- a/tests/fixtures/scorecards/debugging__retries-heavy.json
+++ b/tests/fixtures/scorecards/debugging__retries-heavy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://verdict.dev/schemas/scorecard.v1.json",
+  "$schema": "https://proofloop.dev/schemas/scorecard.v1.json",
   "schemaVersion": "1.0.0",
   "skill": "debugging",
   "timestamp": "2026-04-19T18:59:38Z",

--- a/tests/test_bench_lint.py
+++ b/tests/test_bench_lint.py
@@ -2,7 +2,7 @@
 """Tests for scripts/bench_lint.py and the --lint wire into benchmark_pack.
 
 The lint adapts the Auto Benchmark Audit framework (Wang et al. 2026,
-arXiv:2605.26079) to Verdict's transcript-regression manifest. These
+arXiv:2605.26079) to Proofloop's transcript-regression manifest. These
 tests verify that:
 
 1. The shipped benchmarks/manifest.json passes hygiene cleanly

--- a/tests/test_compare_runs.py
+++ b/tests/test_compare_runs.py
@@ -27,7 +27,7 @@ def _card(
     if dim_scores:
         base.update(dim_scores)
     return {
-        "$schema": "https://verdict.dev/schemas/scorecard.v1.json",
+        "$schema": "https://proofloop.dev/schemas/scorecard.v1.json",
         "schemaVersion": "1.0.0",
         "skill": skill,
         "timestamp": timestamp,

--- a/tests/test_efficiency_duration_ms.py
+++ b/tests/test_efficiency_duration_ms.py
@@ -3,7 +3,7 @@
 
 Claude Code v2.1.119 (2026-04-23) added ``duration_ms`` to
 ``PostToolUse`` and ``PostToolUseFailure`` hook inputs (tool execution
-time, excluding permission prompts and PreToolUse hooks). Verdict's
+time, excluding permission prompts and PreToolUse hooks). Proofloop's
 ``claude_code`` adapter emits ``[tool_duration_ms: <int>]`` per
 record; the efficiency analyzer reports the durations on every
 scorecard and optionally docks 0.5 when ≥3 calls exceed the

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -3,7 +3,7 @@
 
 Every hook reads JSON from stdin and emits either JSON on stdout or
 nothing (graceful exit 0). These tests invoke the scripts via
-subprocess with synthetic payloads to pin the contract that Verdict's
+subprocess with synthetic payloads to pin the contract that Proofloop's
 auto-mode relies on.
 
 We deliberately choose skills that are in neither the `always` nor the

--- a/tests/test_judge_explain.py
+++ b/tests/test_judge_explain.py
@@ -143,7 +143,7 @@ class TestRenderJson(unittest.TestCase):
 class TestRenderMarkdown(unittest.TestCase):
     def test_starts_with_h1(self) -> None:
         text = explain.render_markdown(_sample_card())
-        self.assertTrue(text.startswith("# Verdict Scorecard"))
+        self.assertTrue(text.startswith("# Proofloop Scorecard"))
 
     def test_has_dimension_table_header(self) -> None:
         text = explain.render_markdown(_sample_card())
@@ -203,7 +203,7 @@ class TestCli(unittest.TestCase):
                 ])
                 self.assertEqual(rc, 0)
                 self.assertTrue(out_path.is_file())
-                self.assertIn("# Verdict Scorecard", out_path.read_text())
+                self.assertIn("# Proofloop Scorecard", out_path.read_text())
             finally:
                 card_path.unlink()
 
@@ -364,7 +364,7 @@ class TestRenderHtmlPrintable(unittest.TestCase):
 
     def test_default_cover_title(self) -> None:
         html = explain.render_html_printable(_sample_card(skill="my-skill"))
-        self.assertIn("my-skill — Verdict Scorecard", html)
+        self.assertIn("my-skill — Proofloop Scorecard", html)
 
     def test_explicit_cover_title(self) -> None:
         html = explain.render_html_printable(
@@ -448,7 +448,7 @@ class TestRoundTripFromBuildScorecard(unittest.TestCase):
             )
             saved_path = Path(card["_saved_to"])
             md = explain.render_markdown(explain.load_scorecard(saved_path))
-            self.assertIn("# Verdict Scorecard", md)
+            self.assertIn("# Proofloop Scorecard", md)
             self.assertIn("code-review", md)
 
 

--- a/tests/test_safety_claude_paths.py
+++ b/tests/test_safety_claude_paths.py
@@ -3,7 +3,7 @@
 
 The 2026-04-28 release stopped prompting on writes to
 ``.claude/{skills,agents,commands}/`` under
-``--dangerously-skip-permissions``. Verdict's safety dimension must
+``--dangerously-skip-permissions``. Proofloop's safety dimension must
 not false-positive plugin-author transcripts that edit those paths.
 Destructive shell forms (``rm -rf``, ``chmod 777``, etc.) on the
 same paths still dock the safety dimension.

--- a/tests/test_safety_v2_1_126_paths.py
+++ b/tests/test_safety_v2_1_126_paths.py
@@ -4,7 +4,7 @@
 The 2026-05-01 release widened ``--dangerously-skip-permissions`` to
 also bypass writes to ``.git/``, ``.vscode/``, and shell config files
 (was ``.claude/{skills,agents,commands}/`` only in v2.1.121).
-Verdict's safety-dim helper ``_is_plugin_author_write`` now allowlists
+Proofloop's safety-dim helper ``_is_plugin_author_write`` now allowlists
 the same path classes for non-destructive operations.
 
 Catastrophic removal commands still prompt at the runtime, and verdict

--- a/tests/test_same_family_guard.py
+++ b/tests/test_same_family_guard.py
@@ -207,7 +207,7 @@ class TestGuardIntegration(unittest.TestCase):
         self.assertEqual(sc["same_family_guard"]["executing_family"], "anthropic")
         self.assertEqual(sc["same_family_guard"]["judge_family"], "anthropic")
         self.assertFalse(sc["same_family_guard"]["auto_preferred"])
-        self.assertIn("Verdict WARNING", buf.getvalue())
+        self.assertIn("Proofloop WARNING", buf.getvalue())
         # No alternate → judge model unchanged.
         self.assertEqual(client.last_model, "claude-haiku-4-5")
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Validate every persisted scorecard fixture against scorecard.v1.schema.json.
 
-This is the compatibility gate for the Verdict scorecard JSON shape.
+This is the compatibility gate for the Proofloop scorecard JSON shape.
 When you intentionally evolve the schema, bump ``schemaVersion``, add
 the new fields under ``$defs`` or at the top level, and regenerate the
 fixtures. See DEEP_ANALYSIS.md §Schema stability contract.
@@ -34,7 +34,7 @@ class TestSchemaFileWellFormed(unittest.TestCase):
         schema = _load_schema()
         self.assertEqual(
             schema.get("$id"),
-            "https://verdict.dev/schemas/scorecard.v1.json",
+            "https://proofloop.dev/schemas/scorecard.v1.json",
         )
         self.assertEqual(
             schema.get("$schema"),
@@ -80,7 +80,7 @@ class TestPersistedFixtures(unittest.TestCase):
             document = json.loads(path.read_text(encoding="utf-8"))
             self.assertEqual(
                 document.get("$schema"),
-                "https://verdict.dev/schemas/scorecard.v1.json",
+                "https://proofloop.dev/schemas/scorecard.v1.json",
                 f"{path.name}: missing or wrong $schema",
             )
             self.assertEqual(

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Comprehensive test suite for the Verdict Scoring Engine (score.py).
+"""Comprehensive test suite for the Proofloop Scoring Engine (score.py).
 
 Tests all public functions across 7 categories:
   1. Grade boundaries

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -100,7 +100,7 @@ class TestGenerate(unittest.TestCase):
             studio.generate(scores_dir, output, "2026-04-18 00:00 UTC")
             content = output.read_text(encoding="utf-8")
             self.assertIn("<!doctype html>", content)
-            self.assertIn("Verdict Studio", content)
+            self.assertIn("Proofloop Studio", content)
             self.assertIn("x", content)
 
 

--- a/tests/test_v43_scope_contract.py
+++ b/tests/test_v43_scope_contract.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """v4.3 scope contract — pins the rubric inventory.
 
-Per the 2026-05-03 runbook §scope-reset block, Verdict is a
+Per the 2026-05-03 runbook §scope-reset block, Proofloop is a
 Claude Code / Cowork plugin only. Frontier-lab eval-bench rubrics
 (SWE-bench, Terminal-Bench, GAIA, OSWorld, MCP attack benches,
 etc.) are explicitly out of scope.

--- a/tests/test_verifier_collapse.py
+++ b/tests/test_verifier_collapse.py
@@ -556,14 +556,14 @@ class TestHookGateMode(unittest.TestCase):
             plugin, transcript = self._stage(Path(tmp), gate_mode="warn")
             result = self._run_hook(plugin, transcript)
             self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertIn("Verdict WARNING: verifier collapse", result.stderr)
+            self.assertIn("Proofloop WARNING: verifier collapse", result.stderr)
 
     def test_gate_mode_fail_exits_2_with_stderr_blocked(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             plugin, transcript = self._stage(Path(tmp), gate_mode="fail")
             result = self._run_hook(plugin, transcript)
             self.assertEqual(result.returncode, 2, result.stderr)
-            self.assertIn("Verdict BLOCKED: verifier collapse", result.stderr)
+            self.assertIn("Proofloop BLOCKED: verifier collapse", result.stderr)
 
     def test_gate_mode_off_silent(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -22,7 +22,7 @@ def _card(
     dim_scores: Dict[str, int],
 ) -> Dict[str, Any]:
     return {
-        "$schema": "https://verdict.dev/schemas/scorecard.v1.json",
+        "$schema": "https://proofloop.dev/schemas/scorecard.v1.json",
         "schemaVersion": "1.0.0",
         "skill": skill,
         "timestamp": timestamp,
@@ -154,7 +154,7 @@ class TestCliOncePath(unittest.TestCase):
             ])
             self.assertEqual(rc, 0)
             self.assertTrue(output.is_file())
-            self.assertIn("Verdict Studio", output.read_text(encoding="utf-8"))
+            self.assertIn("Proofloop Studio", output.read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Renames the project **Verdict → Proofloop** to resolve a head-on collision with Haize Labs' open-source `verdict` LLM-judge library (owns PyPI `verdict`, `verdict.haizelabs.com`, $12.5M funded, identical category). The repo is now `sattyamjjain/proofloop` (old URLs redirect).

- Plugin name + `displayName`, schema `$id` (`https://proofloop.dev/schemas/scorecard.v1.json`), README, `SKILL.md`, command docs, agent, hooks, issue templates, and **user-visible script output** (`PROOFLOOP SCORECARD` header, `proofloop-explain`/`proofloop-cost-estimator` CLIs) all rebranded.
- Schema on-disk shape **unchanged** (`scorecard.v1`, additive contract intact) — only the namespace URL moves.
- **v2.0.8 → v3.0.0** (breaking identity change).
- Historical CHANGELOG + `releases/` keep the "Verdict" name they shipped under; the English noun "verdict" (e.g. "a composite verdict") is deliberately preserved.

## Test Plan
- `python3 -m unittest discover tests/` → **650 passed**.
- `python3 scripts/benchmark_pack.py` → **7/7 green**, exit 0.
- `validate_marketplace.py` ✓, `check_readme_release_anchor.py` ✓ (v3.0.0), `test_version_consistency` ✓.
- Live render confirmed: `║ PROOFLOOP SCORECARD -- feature-dev ║`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)