### PR TITLE
feat: GitHub Action CI gate + rendered scorecard demo (v3.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "proofloop",
       "source": "./",
       "description": "Auto-evaluates skill and agent execution quality with 7-dimension scoring, configurable rubrics, and dual-mode operation.",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "category": "quality-assurance",
       "tags": ["judge", "evaluation", "quality", "scoring", "LLM-as-judge"],
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proofloop",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "displayName": "Proofloop — Universal Skill & Agent Quality Judge",
   "description": "The first universal judge for Claude Code & Cowork. Auto-evaluates skill and agent execution quality with 7-dimension scoring, configurable rubrics, and dual-mode operation (auto hooks + manual /judge command).",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,6 +349,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   BrowseComp-Plus (2026-05-06), Managed Agents Outcomes rubric
   beta (2026-05-09).
 
+## [3.1.0] - 2026-06-13
+
+### Added
+
+- **GitHub Action + CI gate.** A repo-root `action.yml` (composite
+  action) plus `scripts/gha_gate.py` let any project run the offline
+  scorer in CI and fail a job when an agent's composite drops below a
+  threshold — `uses: sattyamjjain/proofloop@v3.1.0` with
+  `transcript`/`skill`/`threshold` inputs; exposes `composite` and
+  `grade` step outputs. No API key. Verified across pass / fail /
+  report-only threshold cases.
+- **Rendered-scorecard demo in the README** — a real `report.py` render
+  (not a mockup) showing how an executed-check receipt earns a perfect
+  correctness score.
+
 ## [3.0.0] - 2026-06-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -16,6 +16,38 @@ network call — it ships as a Claude Code plugin that fires on every
 
 ---
 
+## See it
+
+Every execution gets an evidence-based scorecard — rendered in your
+terminal in milliseconds, with no API call and no account:
+
+```text
+╔════════════════════════════════════════════════════════════════════════════╗
+║ PROOFLOOP SCORECARD -- feature-dev                                         ║
+║ Grade: A- (Very Good)  |  Composite: 8.75/10.0  |  2026-06-13T18:05:22Z    ║
+╠════════════════════════════════════════════════════════════════════════════╣
+║ Correctness    ██████████  10.0/10 (w=0.25) → No errors; verification…     ║
+║ Completeness   █████████░   9.0/10 (w=0.20) → Short transcript — may …     ║
+║ Adherence      ████████░░   8.0/10 (w=0.15) → Rubric available (compl…     ║
+║ Actionability  ████████░░   8.0/10 (w=0.15) → Output appears ready to…     ║
+║ Efficiency     ████████░░   8.0/10 (w=0.10) → Reasonable tool usage (…     ║
+║ Safety         ██████████  10.0/10 (w=0.10) → No safety concerns dete…     ║
+║ Consistency    █████░░░░░   5.0/10 (w=0.05) → No prior history for co…     ║
+╠════════════════════════════════════════════════════════════════════════════╣
+║ Summary: Good Feature Dev (A-) -- strong correctness, consistency could i… ║
+║                                                                            ║
+║ RECOMMENDATIONS:                                                           ║
+║   * Compare with prior executions and maintain quality baselines           ║
+╚════════════════════════════════════════════════════════════════════════════╝
+```
+
+That `pytest` receipt in the run is what earns correctness **10/10**:
+without an executed check *anywhere* in the transcript, the top mark is
+withheld — **no pass without proof.** It is no rubber stamp either —
+consistency is held at `5` until there's a history to compare against.
+
+---
+
 ## Install
 
 ```shell
@@ -170,6 +202,27 @@ python3 skills/judge/scripts/explain.py \
 `--format json` emits the same data under a stable
 `format_version: "explain.v1"` schema. See
 [`SKILL-judge-explain.md`](skills/judge/SKILL-judge-explain.md).
+
+---
+
+## Gate your CI on it
+
+Proofloop ships as a GitHub Action, so the same offline scorer can fail a
+pull request when an agent's work drops below your bar — no API key, no
+account:
+
+```yaml
+- uses: sattyamjjain/proofloop@v3.1.0
+  with:
+    transcript: ./agent-run.jsonl   # the agent/skill transcript to score
+    skill: code-review              # selects the rubric
+    threshold: "7.0"                # fail the job below 7.0; omit to report only
+    # adapter: codex                # claude_code | codex | openai_compatible | cowork
+```
+
+It exposes `composite` and `grade` as step outputs and prints a one-line
+summary to the job log. The repo dogfoods this pattern on its own pull
+requests via [`.github/workflows/self-score.yml`](.github/workflows/self-score.yml).
 
 ---
 
@@ -535,12 +588,13 @@ Refs: [arXiv:2606.09068](https://arxiv.org/abs/2606.09068),
 ## Roadmap
 
 See [ROADMAP_2026.md](ROADMAP_2026.md) for the 90-day plan. Latest
-release: [v3.0.0](https://github.com/sattyamjjain/proofloop/releases/tag/v3.0.0)
-(**rebrand to Proofloop** + engine hardening — adherence no longer
-hands out an unearned point for a rubric merely being loaded, and a
-perfect correctness score now requires an execution receipt; offline
-stdlib-only).
+release: [v3.1.0](https://github.com/sattyamjjain/proofloop/releases/tag/v3.1.0)
+(GitHub Action + CI gate — run the offline scorer in CI and fail a job
+below your threshold; plus a real rendered-scorecard demo in the README).
 Previous releases:
+[v3.0.0](https://github.com/sattyamjjain/proofloop/releases/tag/v3.0.0)
+(rebrand to Proofloop + engine hardening — adherence/correctness no
+longer hand out unearned credit),
 [v2.0.8](https://github.com/sattyamjjain/proofloop/releases/tag/v2.0.8)
 (verifier-collapse detector — flags judges that have flatlined at the
 top of the scale over the rolling scorecard window),

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,67 @@
+name: "Proofloop"
+description: "Score an AI agent/skill execution transcript on 7 dimensions and gate CI on the composite. Offline, stdlib-only — no API key."
+author: "Sattyam Jain"
+branding:
+  icon: "check-circle"
+  color: "green"
+
+inputs:
+  transcript:
+    description: "Path to the transcript (JSONL/JSON) to score."
+    required: true
+  skill:
+    description: "Skill name — selects the rubric (exact match, then prefix, then default)."
+    required: false
+    default: "default"
+  adapter:
+    description: "Transcript adapter: claude_code | codex | openai_compatible | cowork. Empty = native Claude Code format."
+    required: false
+    default: ""
+  threshold:
+    description: "Fail the job when the composite is below this (1-10). Empty = report only."
+    required: false
+    default: ""
+  config:
+    description: "Path to a judge-config.json. Empty = Proofloop's bundled config."
+    required: false
+    default: ""
+  python-version:
+    description: "Python version to run the scorer on."
+    required: false
+    default: "3.11"
+
+outputs:
+  composite:
+    description: "Composite score, 1.0-10.0."
+    value: ${{ steps.proofloop.outputs.composite }}
+  grade:
+    description: "Letter grade (A+, A, ... F)."
+    value: ${{ steps.proofloop.outputs.grade }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+    - name: Score transcript
+      id: proofloop
+      shell: bash
+      env:
+        PL_TRANSCRIPT: ${{ inputs.transcript }}
+        PL_SKILL: ${{ inputs.skill }}
+        PL_ADAPTER: ${{ inputs.adapter }}
+        PL_THRESHOLD: ${{ inputs.threshold }}
+        PL_CONFIG: ${{ inputs.config }}
+        PL_ROOT: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+        scores="$(mktemp -d)"
+        args=( --skill "$PL_SKILL" --transcript "$PL_TRANSCRIPT"
+               --rubric-dir "$PL_ROOT/skills/judge/rubrics"
+               --scores-dir "$scores"
+               --config "${PL_CONFIG:-$PL_ROOT/judge-config.json}" )
+        if [ -n "$PL_ADAPTER" ]; then args+=( --adapter "$PL_ADAPTER" ); fi
+        python3 "$PL_ROOT/skills/judge/scripts/score.py" "${args[@]}"
+        python3 "$PL_ROOT/scripts/gha_gate.py" --scores-dir "$scores" --threshold "$PL_THRESHOLD"

--- a/scripts/gha_gate.py
+++ b/scripts/gha_gate.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Emit a Proofloop scorecard result for GitHub Actions and gate on a threshold.
+
+Reads the newest scorecard JSON from ``--scores-dir`` (as written by
+``skills/judge/scripts/score.py``), prints a one-line summary, appends
+``composite`` and ``grade`` to ``$GITHUB_OUTPUT`` when that env var is set,
+and exits non-zero when a ``--threshold`` is given and the composite falls
+below it. Stdlib only; powers the repo-root ``action.yml`` composite action.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+
+
+def _newest_scorecard(scores_dir: str) -> Optional[Path]:
+    """Return the most recently written ``*.json`` scorecard, or None."""
+    files = sorted(Path(p) for p in glob.glob(os.path.join(scores_dir, "*.json")))
+    return files[-1] if files else None
+
+
+def _write_output(composite: object, grade: str) -> None:
+    """Append ``composite``/``grade`` to the GitHub Actions output file."""
+    gh_out = os.environ.get("GITHUB_OUTPUT")
+    if not gh_out:
+        return
+    with open(gh_out, "a", encoding="utf-8") as fh:
+        fh.write(f"composite={composite}\ngrade={grade}\n")
+
+
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(prog="proofloop-gha-gate")
+    parser.add_argument("--scores-dir", required=True, help="Directory score.py wrote to.")
+    parser.add_argument(
+        "--threshold",
+        default="",
+        help="Fail (exit 1) when the composite is below this value (1-10). Empty = report only.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Render the result, export outputs, and enforce the optional gate."""
+    args = parse_args()
+    card_path = _newest_scorecard(args.scores_dir)
+    if card_path is None:
+        print("::error::Proofloop produced no scorecard", file=sys.stderr)
+        return 1
+
+    card = json.loads(card_path.read_text())
+    composite = card.get("composite_score")
+    grade = card.get("grade", "")
+    one_liner = card.get("one_liner", "")
+    print(f"Proofloop: {card.get('skill', '?')} -> {composite}/10 ({grade}) — {one_liner}")
+
+    _write_output(composite, grade)
+
+    threshold = str(args.threshold).strip()
+    if threshold:
+        try:
+            if float(composite) < float(threshold):
+                print(
+                    f"::error::Proofloop composite {composite} is below threshold {threshold}",
+                    file=sys.stderr,
+                )
+                return 1
+        except (TypeError, ValueError):
+            print(f"::warning::invalid threshold {threshold!r}; skipping gate", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/judge/SKILL.md
+++ b/skills/judge/SKILL.md
@@ -2,7 +2,7 @@
 name: judge
 displayName: "Proofloop — Universal Quality Evaluator"
 description: "Evaluates the execution quality of any skill or agent using 7-dimension scoring with configurable rubrics"
-version: "3.0.0"
+version: "3.1.0"
 author: "Sattyam Jain"
 allowed-tools: [Read, Write, Edit, Bash]
 autoActivate:


### PR DESCRIPTION
## Summary
Two relaunch-readiness additions, shipped as **v3.1.0**:

1. **Reusable GitHub Action + CI gate.** A repo-root `action.yml` (composite action) and `scripts/gha_gate.py` let any project run Proofloop's offline scorer in CI and **fail a job when an agent's composite drops below a threshold** — `uses: sattyamjjain/proofloop@v3.1.0` with `transcript` / `skill` / `adapter` / `threshold` / `config` inputs; exposes `composite` and `grade` step outputs. No API key, stdlib only. The repo's own `self-score.yml` already dogfoods the pattern.
2. **Real rendered-scorecard demo in the README** (not a mockup) — an actual `report.py` render placed up top, showing how an executed-check `pytest` receipt earns correctness `10/10` ("no pass without proof"), with consistency held at 5 (no history) so it doesn't read as a rubber stamp.

In scope: packages the existing scorer; no new rubric, adapter, or dimension (v4.3 scope contract untouched).

## Test Plan
- `scripts/gha_gate.py` verified locally across **pass (≥threshold → exit 0)**, **fail (<threshold → exit 1 + `::error::`)**, and **report-only (no threshold → exit 0)**; `composite`/`grade` written to `$GITHUB_OUTPUT`.
- `action.yml` parses as valid YAML.
- `python3 -m unittest discover tests/` → **650 passed**.
- `scripts/benchmark_pack.py` → **7/7 green**.
- version-consistency (3.1.0), `validate_marketplace.py`, `check_readme_release_anchor.py` (v3.1.0) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)