### PR TITLE
fix(rename): complete verdict→proofloop for residual brand identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Completed the `verdict` → `proofloop` rename for the last residual
+  brand identifiers the v3.0.0 rebrand missed: the CLI `prog=` help-text
+  names in `against.py` / `watch.py` / `studio.py` / `compare.py` /
+  `sandbox_caps_check.py` (`verdict-*` → `proofloop-*`), the
+  `install_rubric.py` `User-Agent`, the `hook_lint.py` module docstring,
+  a `validate_marketplace.py` comment, the `--output verdict-studio.html`
+  usage examples, and the SARIF `tool.driver.name` emitted by
+  `bench_lint.py` (`verdict-bench-lint` → `proofloop-bench-lint`, with
+  its pinning assertion in `tests/test_bench_lint.py` updated). English-
+  noun uses of "verdict" (e.g. "composite verdict", "not a leaderboard
+  verdict"), historical CHANGELOG/release entries, disposition records'
+  old-name references, and internal `/tmp/verdict-*` test-fixture paths
+  were intentionally left unchanged. No scored-surface or schema change;
+  654 tests green.
+
 - Rotated the Claude Code release audit comment block in
   `scripts/validate_marketplace.py` to the most-recent five
   releases (newest first): v2.1.129 / v2.1.128 / v2.1.127 / v2.1.126 /

--- a/scripts/bench_lint.py
+++ b/scripts/bench_lint.py
@@ -42,7 +42,7 @@ from typing import Any, Dict, List, Optional, Tuple
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_MANIFEST = PROJECT_ROOT / "benchmarks" / "manifest.json"
 DEFAULT_THRESHOLD = 0.85
-TOOL_NAME = "verdict-bench-lint"
+TOOL_NAME = "proofloop-bench-lint"
 TOOL_VERSION = "2.0.3"
 TOOL_URI = "https://github.com/sattyamjjain/proofloop"
 

--- a/scripts/install_rubric.py
+++ b/scripts/install_rubric.py
@@ -36,7 +36,7 @@ REQUIRED_HEADINGS = [
 def _fetch(url: str, timeout: int = 10) -> Optional[bytes]:
     """Return the bytes at *url* or None on any failure (logged to stderr)."""
     try:
-        req = urllib.request.Request(url, headers={"User-Agent": "verdict-install-rubric/1.1"})
+        req = urllib.request.Request(url, headers={"User-Agent": "proofloop-install-rubric/1.1"})
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             if resp.status != 200:
                 print(f"Error: {url} returned HTTP {resp.status}", file=sys.stderr)

--- a/scripts/sandbox_caps_check.py
+++ b/scripts/sandbox_caps_check.py
@@ -98,7 +98,7 @@ def emit_rationale(
 
 
 def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(prog="verdict-sandbox-caps-check")
+    parser = argparse.ArgumentParser(prog="proofloop-sandbox-caps-check")
     parser.add_argument(
         "--require",
         action="append",

--- a/scripts/validate_marketplace.py
+++ b/scripts/validate_marketplace.py
@@ -31,7 +31,7 @@ Schema source: <https://code.claude.com/docs/en/plugin-marketplaces>
 #   Marketplace-schema-irrelevant.
 # v2.1.127 (≤2026-05-03) — bridge release between v2.1.126 and v2.1.128
 #   per claudefa.st digest; no individually documented surface change
-#   that affects verdict's transcript-shape or safety-allowlist surfaces.
+#   that affects proofloop's transcript-shape or safety-allowlist surfaces.
 #   Marketplace-schema-irrelevant.
 # v2.1.126 (2026-05-01) — /model picker reads gateway /v1/models when
 #   ANTHROPIC_BASE_URL is set; claude project purge [path]; the

--- a/skills/judge/scripts/against.py
+++ b/skills/judge/scripts/against.py
@@ -93,7 +93,7 @@ def render(baseline: Dict[str, Any], target: Dict[str, Any]) -> str:
 
 
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
-    p = argparse.ArgumentParser(prog="verdict-against")
+    p = argparse.ArgumentParser(prog="proofloop-against")
     p.add_argument("--skill", required=True, help="Skill to compare.")
     p.add_argument("--scores-dir", required=True, help="Directory of scorecard JSON files.")
     p.add_argument("--baseline-index", type=int, default=-2,

--- a/skills/judge/scripts/compare.py
+++ b/skills/judge/scripts/compare.py
@@ -161,7 +161,7 @@ def format_report(a: Dict[str, Any], b: Dict[str, Any]) -> str:
 
 
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(prog="verdict-compare")
+    parser = argparse.ArgumentParser(prog="proofloop-compare")
     parser.add_argument("--run-a", required=True, help="Path to the baseline scorecard JSON.")
     parser.add_argument("--run-b", required=True, help="Path to the target scorecard JSON.")
     parser.add_argument(

--- a/skills/judge/scripts/hook_lint.py
+++ b/skills/judge/scripts/hook_lint.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""verdict hook lint — static analyzer for PostToolUse hook scripts.
+"""proofloop hook lint — static analyzer for PostToolUse hook scripts.
 
 Lints a hook script (``.sh`` / ``.py`` / ``.js`` / ``.ts``) that
 targets the Claude Code ``PostToolUse`` lifecycle and may emit

--- a/skills/judge/scripts/studio.py
+++ b/skills/judge/scripts/studio.py
@@ -13,7 +13,7 @@ dependencies on either side. Stdlib-only Python generator.
 Usage:
     python3 skills/judge/scripts/studio.py \\
       --scores-dir skills/judge/scores \\
-      --output verdict-studio.html
+      --output proofloop-studio.html
 """
 from __future__ import annotations
 
@@ -216,7 +216,7 @@ def generate(scores_dir: Path, output: Path, now: str) -> None:
 
 
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
-    p = argparse.ArgumentParser(prog="verdict-studio")
+    p = argparse.ArgumentParser(prog="proofloop-studio")
     p.add_argument("--scores-dir", required=True, help="Directory containing score JSON files.")
     p.add_argument("--output", required=True, help="Output HTML file path.")
     return p.parse_args(argv)

--- a/skills/judge/scripts/watch.py
+++ b/skills/judge/scripts/watch.py
@@ -15,7 +15,7 @@ beyond the main one. Exits on SIGINT.
 Usage:
     python3 skills/judge/scripts/watch.py \\
       --scores-dir skills/judge/scores \\
-      --output verdict-studio.html \\
+      --output proofloop-studio.html \\
       [--interval 2.0] [--once]
 
 The ``--once`` flag runs a single pass (used by tests); omit it to
@@ -144,7 +144,7 @@ def run_pass(
 
 
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(prog="verdict-watch")
+    parser = argparse.ArgumentParser(prog="proofloop-watch")
     parser.add_argument(
         "--scores-dir", required=True,
         help="Directory of persisted scorecard JSON files to watch.",

--- a/tests/cli/test_hook_lint.py
+++ b/tests/cli/test_hook_lint.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for verdict hook lint CLI (T3, v1.4.2)."""
+"""Tests for proofloop hook lint CLI (T3, v1.4.2)."""
 from __future__ import annotations
 
 import io

--- a/tests/test_bench_lint.py
+++ b/tests/test_bench_lint.py
@@ -369,7 +369,7 @@ class TestSarifShape(unittest.TestCase):
             self.assertEqual(len(sarif["runs"]), 1)
             run = sarif["runs"][0]
             self.assertEqual(
-                run["tool"]["driver"]["name"], "verdict-bench-lint"
+                run["tool"]["driver"]["name"], "proofloop-bench-lint"
             )
             rule_ids = [r["id"] for r in run["tool"]["driver"]["rules"]]
             self.assertEqual(


### PR DESCRIPTION
## Summary

Completes the `verdict` → `proofloop` rename for the last residual brand identifiers the v3.0.0 rebrand missed. **Scope decision:** full completion (chosen over cosmetic-only), so the SARIF driver name is renamed too.

Renamed:
- CLI `prog=` help-text names: `against.py`, `watch.py`, `studio.py`, `compare.py`, `sandbox_caps_check.py` (`verdict-*` → `proofloop-*`)
- `install_rubric.py` `User-Agent`; `hook_lint.py` module docstring; a `validate_marketplace.py` comment; the `--output verdict-studio.html` usage examples
- SARIF `tool.driver.name` in `bench_lint.py` (`verdict-bench-lint` → `proofloop-bench-lint`), with its pinning assertion in `tests/test_bench_lint.py` updated

Intentionally left unchanged: English-noun "verdict" ("composite verdict", "not a leaderboard verdict"), historical CHANGELOG/release entries, disposition records' old-name references, and internal `/tmp/verdict-*` test-fixture paths.

**Not in this PR (already done / out of scope):** Bugs 1 (adherence `+1`) and 2 (correctness gameable by avoiding "error") were already fixed and tested in v3.0.0–v3.1.1 — `_analyze_adherence` deviation-only baseline and the `_US_RECEIPT` correctness cap; re-doing them was skipped to avoid regressing working code. No PyPI reserve (this is a Claude Code plugin, not a pip package), no `verdict` user alias (the plugin is `/judge`), no feature version bump (cosmetic cleanup → `[Unreleased]`).

No scored-surface or schema change.

## Test Plan

```
python3 -m unittest discover tests/
# Ran 654 tests ... OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)